### PR TITLE
Add basic zpool functionality for ZFSPool

### DIFF
--- a/src/py_zfs.c
+++ b/src/py_zfs.c
@@ -140,6 +140,46 @@ PyObject *py_zfs_resource_open(PyObject *self,
 	return out;
 }
 
+PyObject *py_zfs_pool_open(PyObject *self,
+                             PyObject *args_unused,
+                             PyObject *kwargs)
+{
+	PyObject *out = NULL;
+	py_zfs_t *plz = (py_zfs_t *)self;
+	zpool_handle_t *zhp = NULL;
+	char *name = NULL;
+	py_zfs_error_t zfs_err;
+
+	char *kwnames [] = { "pool_name", NULL };
+
+	if (!PyArg_ParseTupleAndKeywords(args_unused, kwargs,
+					"$s",
+					kwnames,
+					&name)) {
+			return (NULL);
+	}
+
+	Py_BEGIN_ALLOW_THREADS
+	PY_ZFS_LOCK(plz);
+	zhp = zpool_open(plz->lzh, name);
+	if (zhp == NULL) {
+			py_get_zfs_error(plz->lzh, &zfs_err);
+	}
+	PY_ZFS_UNLOCK(plz);
+	Py_END_ALLOW_THREADS
+
+	if (zhp == NULL) {
+			set_exc_from_libzfs(&zfs_err, "zfs_open() failed");
+			return (NULL);
+	}
+
+	out = (PyObject *)init_zfs_pool(plz, zhp);
+	if (out == NULL)
+		zpool_close(zhp);
+
+	return (out);
+}
+
 PyGetSetDef zfs_getsetters[] = {
 	{
 		.name	= "proptypes",
@@ -152,6 +192,11 @@ PyMethodDef zfs_methods[] = {
 	{
 		.ml_name = "open_resource",
 		.ml_meth = (PyCFunction)py_zfs_resource_open,
+		.ml_flags = METH_VARARGS | METH_KEYWORDS
+	},
+	{
+		.ml_name = "open_pool",
+		.ml_meth = (PyCFunction)py_zfs_pool_open,
 		.ml_flags = METH_VARARGS | METH_KEYWORDS
 	},
 	{ NULL, NULL, 0, NULL }

--- a/src/pylibzfs2.h
+++ b/src/pylibzfs2.h
@@ -94,8 +94,7 @@ typedef struct {
 	PyObject_HEAD
 	py_zfs_t *pylibzfsp;
 	zpool_handle_t *zhp;
-	boolean_t free;
-	const PyObject *root;
+	PyObject *name;
 } py_zfs_pool_t;
 
 typedef struct {
@@ -220,6 +219,9 @@ extern void _set_exc_from_libzfs(py_zfs_error_t *err,
  * GIL must be held when this is called.
  */
 extern py_zfs_dataset_t *init_zfs_dataset(py_zfs_t *lzp, zfs_handle_t *zfsp);
+
+/* Provided by py_zfs_pool.c */
+extern py_zfs_pool_t *init_zfs_pool(py_zfs_t *lzp, zpool_handle_t *zhp);
 
 /* Provided by utils.c */
 extern const char *get_dataset_type(zfs_type_t type);


### PR DESCRIPTION
This commit adds basic functionality for ZFSPool.

    * Open the pool and return ZFSPool object
    * Stores pool name as python str
    * Return ZFSDataset object for root dataset
    * Implements zpool clear
    * Implements zpool delete
    * Implements zpool upgrade
    * Implements zpool prefetch
    * Implements zpool ddt_prune