### PR TITLE
Add module state struct and improve ZFS dataset object

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ truenas_pylibzfs = Extension(
         'src/py_zfs_pool.c',
         'src/py_zfs_prop.c',
         'src/py_zfs_resource.c',
+        'src/py_zfs_state.c',
         'src/pylibzfs2.c',
         'src/utils.c',
     ],

--- a/src/py_zfs_dataset.c
+++ b/src/py_zfs_dataset.c
@@ -201,7 +201,7 @@ py_zfs_dataset_t *init_zfs_dataset(py_zfs_t *lzp, zfs_handle_t *zfsp)
 		goto error;
 
 	obj->ctype = zfs_type;
-	obj->type = py_get_zfs_type(lzp, zfs_type);
+	obj->type_enum = py_get_zfs_type(lzp, zfs_type, &obj->type);
 	obj->guid = Py_BuildValue("k", guid);
 	if (obj->guid == NULL)
 		goto error;

--- a/src/py_zfs_dataset.c
+++ b/src/py_zfs_dataset.c
@@ -154,7 +154,7 @@ PyMethodDef zfs_dataset_methods[] = {
 };
 
 PyTypeObject ZFSDataset = {
-	.tp_name = "ZFSDataset",
+	.tp_name = PYLIBZFS_MODULE_NAME ".ZFSDataset",
 	.tp_basicsize = sizeof (py_zfs_dataset_t),
 	.tp_methods = zfs_dataset_methods,
 	.tp_getset = zfs_dataset_getsetters,
@@ -173,7 +173,6 @@ py_zfs_dataset_t *init_zfs_dataset(py_zfs_t *lzp, zfs_handle_t *zfsp)
 	py_zfs_obj_t *obj = NULL;
 	const char *ds_name;
 	const char *pool_name;
-	const char *ds_type;
 	zfs_type_t zfs_type;
 	uint64_t guid, createtxg;
 
@@ -189,7 +188,6 @@ py_zfs_dataset_t *init_zfs_dataset(py_zfs_t *lzp, zfs_handle_t *zfsp)
 	ds_name = zfs_get_name(zfsp);
 	zfs_type = zfs_get_type(zfsp);
 	pool_name = zfs_get_pool_name(zfsp);
-	ds_type = get_dataset_type(zfs_type);
 	guid = zfs_prop_get_int(zfsp, ZFS_PROP_GUID);
 	createtxg = zfs_prop_get_int(zfsp, ZFS_PROP_CREATETXG);
 	Py_END_ALLOW_THREADS
@@ -203,10 +201,7 @@ py_zfs_dataset_t *init_zfs_dataset(py_zfs_t *lzp, zfs_handle_t *zfsp)
 		goto error;
 
 	obj->ctype = zfs_type;
-	obj->type = PyUnicode_FromString(ds_type);
-	if (obj->type == NULL)
-		goto error;
-
+	obj->type = py_get_zfs_type(lzp, zfs_type);
 	obj->guid = Py_BuildValue("k", guid);
 	if (obj->guid == NULL)
 		goto error;

--- a/src/py_zfs_object.c
+++ b/src/py_zfs_object.c
@@ -26,6 +26,7 @@ void py_zfs_obj_dealloc(py_zfs_obj_t *self) {
 	Py_CLEAR(self->name);
 	Py_CLEAR(self->pool_name);
 	Py_CLEAR(self->type);
+	Py_CLEAR(self->type_enum);
 	Py_CLEAR(self->pylibzfsp);
 	Py_CLEAR(self->guid);
 	Py_CLEAR(self->createtxg);
@@ -137,7 +138,7 @@ PyDoc_STRVAR(py_zfs_obj_type__doc__,
 );
 static
 PyObject *py_zfs_obj_get_type(py_zfs_obj_t *self, void *extra) {
-	return py_get_prop(self->type);
+	return py_get_prop(self->type_enum);
 }
 
 PyDoc_STRVAR(py_zfs_obj_guid__doc__,

--- a/src/py_zfs_state.c
+++ b/src/py_zfs_state.c
@@ -1,0 +1,82 @@
+#include "pylibzfs2.h"
+
+static
+int setup_zfs_type(PyObject *module, pylibzfs_state_t *state)
+{
+	uint i, j;
+	PyObject *pyenum;
+
+	pyenum = PyObject_GetAttrString(module, "ZFSType");
+	if (pyenum == NULL)
+		return -1;
+
+	for (i = 0; i < ARRAY_SIZE(state->zfs_type_enum); i++) {
+		PyObject *enum_val, *enum_key;
+
+		enum_key = Py_BuildValue("i", zfs_type_table[i].type);
+		if (enum_key == NULL) {
+			goto fail;
+		}
+		enum_val = PyObject_CallOneArg(pyenum, enum_key);
+		Py_DECREF(enum_key);
+		if (enum_val == NULL) {
+			goto fail;
+		}
+
+		state->zfs_type_enum[i].obj = enum_val;
+		state->zfs_type_enum[i].type = zfs_type_table[i].type;
+	}
+
+	return 0;
+
+fail:
+	for (j = 0; j < i; j++)
+		Py_CLEAR(state->zfs_type_enum[j].obj);
+
+	return -1;
+}
+
+pylibzfs_state_t *py_get_module_state(py_zfs_t *zfs)
+{
+	pylibzfs_state_t *state = NULL;
+
+	state = (pylibzfs_state_t *)PyModule_GetState(zfs->module);
+	PYZFS_ASSERT(state, "Failed to get module state.");
+
+	return state;
+}
+
+int init_py_zfs_state(PyObject *module)
+{
+	int err;
+	pylibzfs_state_t *state = NULL;
+
+	state = (pylibzfs_state_t *)PyModule_GetState(module);
+	PYZFS_ASSERT(state, "Failed to get module state.");
+
+	/* Populate state lookup tables with pointers to enums
+	 * allocated during enum init
+	 */
+	err = setup_zfs_type(module, state);
+	PYZFS_ASSERT(err == 0, "Failed to setup ZFS type in module state.");
+
+	return 0;
+}
+
+PyObject *py_get_zfs_type(py_zfs_t *zfs, zfs_type_t type)
+{
+	PyObject *out = NULL;
+	pylibzfs_state_t *state = NULL;
+	uint i;
+
+	state = py_get_module_state(zfs);
+
+	for (i = 0; i < ARRAY_SIZE(state->zfs_type_enum); i++) {
+		if (zfs_type_table[i].type == type) {
+			out = state->zfs_type_enum[i].obj;
+		}
+	}
+
+	PYZFS_ASSERT(out, "Failed to get reference for zfs_type_t enum");
+	return Py_NewRef(out);
+}

--- a/src/py_zfs_state.h
+++ b/src/py_zfs_state.h
@@ -1,7 +1,7 @@
 #ifndef	_PYZFS_STATE_H
 #define _PYZFS_STATE_H
 
-typedef struct { zfs_type_t type; PyObject *obj; } pystate_zfstype_t;
+typedef struct { zfs_type_t type; PyObject *obj; PyObject *name;} pystate_zfstype_t;
 
 typedef struct {
 	/* Per-module instance lookup tables for enum entries */

--- a/src/py_zfs_state.h
+++ b/src/py_zfs_state.h
@@ -1,0 +1,12 @@
+#ifndef	_PYZFS_STATE_H
+#define _PYZFS_STATE_H
+
+typedef struct { zfs_type_t type; PyObject *obj; } pystate_zfstype_t;
+
+typedef struct {
+	/* Per-module instance lookup tables for enum entries */
+	pystate_zfstype_t zfs_type_enum[ARRAY_SIZE(zfs_type_table)];
+} pylibzfs_state_t;
+
+extern int init_py_zfs_state(PyObject *module);
+#endif /* _PYZFS_STATE_H */

--- a/src/pylibzfs2.h
+++ b/src/pylibzfs2.h
@@ -73,6 +73,7 @@ typedef struct {
 	zfs_handle_t *zhp;
 	zfs_type_t ctype;
 	PyObject *type;
+	PyObject *type_enum;
 	PyObject *name;
 	PyObject *guid;
 	PyObject *createtxg;
@@ -285,10 +286,11 @@ extern int py_add_zfs_enums(PyObject *module);
  * @return	returns pointer to the initialized pylibzfs_state_t struct
  *		for the module instance under which `zfs` was allocated.
  *
- * NOTE: this call asserts on failure.
+ * @note this call asserts on failure.
  *
- * GIL must be held when this is called.
- * Does not require taking mutex in py_zfs_t object.
+ * @note the GIL must be held when calling this function.
+ *
+ * @note does not require taking mutex in py_zfs_t object.
  */
 extern pylibzfs_state_t *py_get_module_state(py_zfs_t *zfs);
 
@@ -302,12 +304,16 @@ extern pylibzfs_state_t *py_get_module_state(py_zfs_t *zfs);
  *
  * @param[in] zfs - pointer to py_zfs_t object.
  * @param[in] type - zfs_type_t type to look up.
+ * @param[out] name - reference to unicode object of zts_type_t name.
  *
- * NOTE: this call asserts on failure.
+ * @note the `name` parameter is optional and will not be retrieved if set to NULL
  *
- * GIL must be held when this is called.
- * Does not require taking mutex in py_zfs_t object.
+ * @note this call asserts on failure.
+ *
+ * @note the GIL must be held when calling this function.
+ *
+ * @note does not require taking mutex in py_zfs_t object.
  */
-extern PyObject *py_get_zfs_type(py_zfs_t *zfs, zfs_type_t type);
+extern PyObject *py_get_zfs_type(py_zfs_t *zfs, zfs_type_t type, PyObject **name);
 
 #endif  /* _PYLIBZFS2_H */

--- a/src/pylibzfs2.h
+++ b/src/pylibzfs2.h
@@ -2,6 +2,7 @@
 #define _PYLIBZFS2_H
 #include "zfs.h"
 #include "pylibzfs2_enums.h"
+#include "py_zfs_state.h"
 
 #define PYLIBZFS_MODULE_NAME "truenas_pylibzfs"
 #define SUPPORTED_RESOURCES ZFS_TYPE_VOLUME | ZFS_TYPE_FILESYSTEM
@@ -31,6 +32,7 @@
  */
 typedef struct {
 	PyObject_HEAD
+	PyObject *module;
 	libzfs_handle_t *lzh;
 	pthread_mutex_t zfs_lock;
 	boolean_t mnttab_cache_enable;
@@ -269,5 +271,43 @@ extern int py_log_history_fmt(py_zfs_t *pyzfs, const char *fmt, ...);
 
 /* Provided by py_zfs_enum.c */
 extern int py_add_zfs_enums(PyObject *module);
+
+/* Provided by py_zfs_state.c */
+/*
+ * @brief retrieve the module state for a give py_zfs_t object
+ *
+ * When a module instance is created (for example on module import), a module
+ * state struct is allocated and populated with references to commonly-used
+ * objects (for instance enum values). This function returns a pointer to the
+ * state struct associated with a particul py_zfs_t object.
+ *
+ * @param[in]	zfs - pointer to py_zfs_t object.
+ * @return	returns pointer to the initialized pylibzfs_state_t struct
+ *		for the module instance under which `zfs` was allocated.
+ *
+ * NOTE: this call asserts on failure.
+ *
+ * GIL must be held when this is called.
+ * Does not require taking mutex in py_zfs_t object.
+ */
+extern pylibzfs_state_t *py_get_module_state(py_zfs_t *zfs);
+
+/*
+ * @brief get a reference to truenas_libzfs.ZFSType for specified zfs_type_t
+ *
+ * This function retrieves a reference to the assocatiated truenas_libzfs.ZFSType
+ * object assocated with a specified zfs_type_t enum value from the module state
+ * struct associated with the specified py_zfs_t object. This is a faster alternative
+ * to calling the enum object from the C API.
+ *
+ * @param[in] zfs - pointer to py_zfs_t object.
+ * @param[in] type - zfs_type_t type to look up.
+ *
+ * NOTE: this call asserts on failure.
+ *
+ * GIL must be held when this is called.
+ * Does not require taking mutex in py_zfs_t object.
+ */
+extern PyObject *py_get_zfs_type(py_zfs_t *zfs, zfs_type_t type);
 
 #endif  /* _PYLIBZFS2_H */

--- a/src/pylibzfs2.h
+++ b/src/pylibzfs2.h
@@ -279,7 +279,7 @@ extern int py_add_zfs_enums(PyObject *module);
  * When a module instance is created (for example on module import), a module
  * state struct is allocated and populated with references to commonly-used
  * objects (for instance enum values). This function returns a pointer to the
- * state struct associated with a particul py_zfs_t object.
+ * state struct associated with a particular py_zfs_t object.
  *
  * @param[in]	zfs - pointer to py_zfs_t object.
  * @return	returns pointer to the initialized pylibzfs_state_t struct


### PR DESCRIPTION
This commit makes the following changes:
* Adds a backpointer to py_zfs_t objects to the originating module object. This required changing how truenas_pylibzfs.ZFS objects are created (now via a module method rather than calling the object).
* Adds a utility function to get a pointer to the module state struct based on a give py_zfs_t object.
* Defines struct for py_zfs_state and adds lookup table for converting zfs_type_t to new reference of truenas_pylibzfs.ZFSType object.
* Adds docstring for `truenas_pylibzfs.open_handle` module method.