### PR TITLE
Fix buffer for history prefix in ZFS object

### DIFF
--- a/src/pylibzfs2.h
+++ b/src/pylibzfs2.h
@@ -5,6 +5,7 @@
 
 #define PYLIBZFS_MODULE_NAME "truenas_pylibzfs"
 #define SUPPORTED_RESOURCES ZFS_TYPE_VOLUME | ZFS_TYPE_FILESYSTEM
+#define MAX_HISTORY_PREFIX_LEN 25
 
 /*
  * Macro to handle extreme error case in module. This should only be invoked
@@ -34,7 +35,7 @@ typedef struct {
 	pthread_mutex_t zfs_lock;
 	boolean_t mnttab_cache_enable;
 	int history;
-	const char *history_prefix;
+	char history_prefix[MAX_HISTORY_PREFIX_LEN];
 	PyObject *proptypes;
 } py_zfs_t;
 


### PR DESCRIPTION
Copy the history prefix into a pre-allocated buffer in the ZFS object struct. This avoids potential for UAF once the python unicode object under which the prefix string is garbage collected.