### PR TITLE
Improve error handling in zpool_log_history

### DIFF
--- a/src/pylibzfs2.h
+++ b/src/pylibzfs2.h
@@ -257,8 +257,13 @@ extern PyObject *py_repr_zfs_obj_impl(py_zfs_obj_t *obj, const char *fmt);
  * @return	int 0 on success -1 on error. Error can happen if ZFS ioctl
  * 		fails.
  *
- * @note The py_zfs_t lock for the libzfs handle should be held while writing
- * history since a ZFS error may be written on ioctl failure.
+ * @note This function will truncate the message to 4096 bytes.
+ *
+ * @note The GIL must be held when calling this function.
+ *
+ * @note On failure, exception will be set by python signal handler in case
+ *     of a EINTR, otherwise a RuntimeError will be set with error text
+ *     containing the history message and errno details.
  */
 extern int py_log_history_fmt(py_zfs_t *pyzfs, const char *fmt, ...);
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -54,6 +54,8 @@ int py_log_history_fmt(py_zfs_t *pyzfs, const char *fmt, ...)
 	char histbuf[PYMAXHISTORYLEN];
 	va_list args;
 	size_t sz;
+	int err;
+	int async_err = 0;
 
 	if (!pyzfs->history)
 		return 0;
@@ -65,5 +67,29 @@ int py_log_history_fmt(py_zfs_t *pyzfs, const char *fmt, ...)
 	vsnprintf(histbuf + sz, sizeof(histbuf) - sz, fmt, args);
 	va_end(args);
 
-	return zpool_log_history(pyzfs->lzh, histbuf);
+	do {
+		// We do not need to PYZFS_LOCK(pyzfs) because
+		// zpool_log_history does not set a ZFS errno
+		Py_BEGIN_ALLOW_THREADS
+		err = zpool_log_history(pyzfs->lzh, histbuf);
+		Py_END_ALLOW_THREADS
+	} while (err < 0 && errno == EINTR && !(async_err = PyErr_CheckSignals()));
+
+	if (async_err) {
+		// Python has already set exception
+		return -1;
+	} else if (err) {
+		PyErr_Format(PyExc_RuntimeError,
+			     "[%s]: attempt to log action to zpool history "
+			     "failed with error [%d]: %s. Since logging occurs "
+			     "after the action completes, this means that the "
+			     "specificed action completed successfully; however "
+			     "it will not be logged in the normal zpool history "
+			     "log. NOTE: the action will still be logged in some "
+			     "capacity in the internal zpool log.",
+			     histbuf, errno, strerror(errno));
+		return -1;
+	}
+
+	return 0;
 }


### PR DESCRIPTION
This commit retries to log zpool history in case of failure with EINTR in which the python signal handler hasn't caught the signal and already set an exception. Otherwise, a RuntimeError is set with the missing zpool history line and OS error information.