### PR TITLE
Add history and audit logs for ZFSPool

### DIFF
--- a/src/py_zfs.c
+++ b/src/py_zfs.c
@@ -160,6 +160,19 @@ PyObject *py_zfs_pool_open(PyObject *self,
 			return (NULL);
 	}
 
+	if (!name) {
+		PyErr_SetString(PyExc_ValueError,
+				"The name of the pool to open must be "
+				"passed to this method through the "
+				"\"pool_name\" keyword argument.");
+		return NULL;
+	}
+
+	if (PySys_Audit(PYLIBZFS_MODULE_NAME ".open_pool", "s",
+			name) < 0) {
+		return NULL;
+	}
+
 	Py_BEGIN_ALLOW_THREADS
 	PY_ZFS_LOCK(plz);
 	zhp = zpool_open(plz->lzh, name);

--- a/src/py_zfs_pool.c
+++ b/src/py_zfs_pool.c
@@ -55,6 +55,11 @@ PyObject *py_zfs_pool_root_dataset(PyObject *self, PyObject *args) {
 	PyObject *fargs = NULL;
 	PyObject *fkwargs = NULL;
 
+	if (PySys_Audit(PYLIBZFS_MODULE_NAME ".ZFSPool.root_dataset", "O",
+	    p->name) < 0) {
+		return NULL;
+	}
+
 	fargs = PyTuple_New(0);
 	if (fargs == NULL)
 		return (NULL);
@@ -83,6 +88,11 @@ PyObject *py_zfs_pool_root_vdev(PyObject *self, PyObject *args) {
 	py_zfs_pool_t *p = (py_zfs_pool_t *)self;
 	nvlist_t *nvroot;
 
+	if (PySys_Audit(PYLIBZFS_MODULE_NAME ".ZFSPool.root_vdev", "O",
+	    p->name) < 0) {
+		return NULL;
+	}
+
 	Py_BEGIN_ALLOW_THREADS
 	nvroot = fnvlist_lookup_nvlist(zpool_get_config(p->zhp, NULL),
 	    ZPOOL_CONFIG_VDEV_TREE);
@@ -98,6 +108,11 @@ PyObject *py_zfs_pool_clear(PyObject *self, PyObject *args) {
 	nvlist_t *policy = NULL;
 	py_zfs_pool_t *p = (py_zfs_pool_t *)self;
 	py_zfs_error_t err;
+
+	if (PySys_Audit(PYLIBZFS_MODULE_NAME ".ZFSPool.clear", "O",
+	    p->name) < 0) {
+		return NULL;
+	}
 
 	Py_BEGIN_ALLOW_THREADS
 	policy = fnvlist_alloc();
@@ -129,6 +144,12 @@ PyObject *py_zfs_pool_upgrade(PyObject *self, PyObject *args) {
 	py_zfs_pool_t *p = (py_zfs_pool_t *)self;
 	py_zfs_error_t err;
 
+	if (PySys_Audit(PYLIBZFS_MODULE_NAME ".ZFSPool.upgrade", "O",
+	    p->name) < 0) {
+		return NULL;
+	}
+
+
 	Py_BEGIN_ALLOW_THREADS
 	PY_ZFS_LOCK(p->pylibzfsp);
 	ret = zpool_upgrade(p->zhp, SPA_VERSION);
@@ -157,6 +178,11 @@ PyObject *py_zfs_pool_delete(PyObject *self, PyObject *args, PyObject *kwargs) {
 		return NULL;
 	}
 
+	if (PySys_Audit(PYLIBZFS_MODULE_NAME ".ZFSPool.delete", "OO",
+	    p->name, kwargs) < 0) {
+		return NULL;
+	}
+
 	Py_BEGIN_ALLOW_THREADS
 	PY_ZFS_LOCK(p->pylibzfsp);
 	ret = zpool_disable_datasets(p->zhp, force);
@@ -180,6 +206,11 @@ PyObject *py_zfs_pool_ddt_prefetch(PyObject *self, PyObject *args) {
 	int ret = 0;
 	py_zfs_pool_t *p = (py_zfs_pool_t *)self;
 	py_zfs_error_t err;
+
+	if (PySys_Audit(PYLIBZFS_MODULE_NAME ".ZFSPool.ddt_prefetch", "O",
+	    p->name) < 0) {
+		return NULL;
+	}
 
 	Py_BEGIN_ALLOW_THREADS
 	PY_ZFS_LOCK(p->pylibzfsp);
@@ -224,6 +255,11 @@ PyObject *py_zfs_pool_ddt_prune(PyObject *self,
 	} else if (days == 0 && percentage == 0) {
 		PyErr_SetString(PyExc_ValueError,
 			"Either days or percentage must be set");
+	}
+
+	if (PySys_Audit(PYLIBZFS_MODULE_NAME ".ZFSPool.ddt_prune", "OO",
+	    p->name, kwargs) < 0) {
+		return NULL;
 	}
 
 	if (percentage != 0) {

--- a/src/py_zfs_pool.c
+++ b/src/py_zfs_pool.c
@@ -144,7 +144,7 @@ PyDoc_STRVAR(py_zfs_pool_clear__doc__,
 );
 static
 PyObject *py_zfs_pool_clear(PyObject *self, PyObject *args) {
-	int ret = 0;
+	int ret = 0, error;
 	nvlist_t *policy = NULL;
 	py_zfs_pool_t *p = (py_zfs_pool_t *)self;
 	py_zfs_error_t err;
@@ -173,6 +173,14 @@ PyObject *py_zfs_pool_clear(PyObject *self, PyObject *args) {
 	if (ret) {
 		set_exc_from_libzfs(&err, "zpool_clear() failed");
 		return (NULL);
+	} else {
+		error = py_log_history_fmt(p->pylibzfsp,
+		    "zpool clear %s", zpool_get_name(p->zhp));
+		if (error) {
+			// An exception should be set since we failed to log
+			// history
+			return (NULL);
+		}
 	}
 
 	Py_RETURN_NONE;
@@ -195,7 +203,7 @@ PyDoc_STRVAR(py_zfs_pool_upgrade__doc__,
 );
 static
 PyObject *py_zfs_pool_upgrade(PyObject *self, PyObject *args) {
-	int ret = 0;
+	int ret = 0, error;
 	py_zfs_pool_t *p = (py_zfs_pool_t *)self;
 	py_zfs_error_t err;
 
@@ -216,6 +224,14 @@ PyObject *py_zfs_pool_upgrade(PyObject *self, PyObject *args) {
 	if (ret) {
 		set_exc_from_libzfs(&err, "zpool_upgrade() failed");
 		return (NULL);
+	} else {
+		error = py_log_history_fmt(p->pylibzfsp,
+		    "zpool upgrade %s", zpool_get_name(p->zhp));
+		if (error) {
+			// An exception should be set since we failed to log
+			// history
+			return (NULL);
+		}
 	}
 
 	Py_RETURN_NONE;
@@ -239,7 +255,7 @@ PyDoc_STRVAR(py_zfs_pool_delete__doc__,
 );
 static
 PyObject *py_zfs_pool_delete(PyObject *self, PyObject *args, PyObject *kwargs) {
-	int ret, force;
+	int ret, force, error;
 	py_zfs_pool_t *p = (py_zfs_pool_t *)self;
 	py_zfs_error_t err;
 	ret = force = 0;
@@ -267,6 +283,15 @@ PyObject *py_zfs_pool_delete(PyObject *self, PyObject *args, PyObject *kwargs) {
 	if (ret) {
 		set_exc_from_libzfs(&err, "zpool_delete() failed");
 		return (NULL);
+	} else {
+		error = py_log_history_fmt(p->pylibzfsp,
+		    "zpool destroy %s%s", force ? "-f " : "",
+		    zpool_get_name(p->zhp));
+		if (error) {
+			// An exception should be set since we failed to log
+			// history
+			return (NULL);
+		}
 	}
 
 	Py_RETURN_NONE;
@@ -289,7 +314,7 @@ PyDoc_STRVAR(py_zfs_pool_ddt_prefetch__doc__,
 );
 static
 PyObject *py_zfs_pool_ddt_prefetch(PyObject *self, PyObject *args) {
-	int ret = 0;
+	int ret = 0, error;
 	py_zfs_pool_t *p = (py_zfs_pool_t *)self;
 	py_zfs_error_t err;
 
@@ -309,6 +334,14 @@ PyObject *py_zfs_pool_ddt_prefetch(PyObject *self, PyObject *args) {
 	if (ret) {
 		set_exc_from_libzfs(&err, "zpool_ddt_prefetch() failed");
 		return (NULL);
+	} else {
+		error = py_log_history_fmt(p->pylibzfsp,
+		    "zpool prefetch %s", zpool_get_name(p->zhp));
+		if (error) {
+			// An exception should be set since we failed to log
+			// history
+			return (NULL);
+		}
 	}
 
 	Py_RETURN_NONE;
@@ -339,7 +372,7 @@ static
 PyObject *py_zfs_pool_ddt_prune(PyObject *self,
 				PyObject *args,
 				PyObject *kwargs) {
-	int ret;
+	int ret, error;
 	unsigned int days, percentage;
 	uint64_t value = 0;
 	py_zfs_pool_t *p = (py_zfs_pool_t *)self;
@@ -389,6 +422,15 @@ PyObject *py_zfs_pool_ddt_prune(PyObject *self,
 	if (ret) {
 		set_exc_from_libzfs(&err, "zpool_ddt_prune() failed");
 		return (NULL);
+	} else {
+		error = py_log_history_fmt(p->pylibzfsp,
+		    "zpool ddtprune %s%llu %s", days ? "-d ": "-p ", value,
+		    zpool_get_name(p->zhp));
+		if (error) {
+			// exception should be set since we failed to log
+			// history
+			return (NULL);
+		}
 	}
 
 	Py_RETURN_NONE;

--- a/src/py_zfs_pool.c
+++ b/src/py_zfs_pool.c
@@ -373,7 +373,7 @@ PyObject *py_zfs_pool_ddt_prune(PyObject *self,
 				PyObject *args,
 				PyObject *kwargs) {
 	int ret, error;
-	unsigned int days, percentage;
+	int days, percentage;
 	uint64_t value = 0;
 	py_zfs_pool_t *p = (py_zfs_pool_t *)self;
 	py_zfs_error_t err;
@@ -381,12 +381,12 @@ PyObject *py_zfs_pool_ddt_prune(PyObject *self,
 	char *kwnames[] = {"days", "percentage", NULL};
 	ret = days = percentage = 0;
 
-	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|II", kwnames, &days,
+	if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|ii", kwnames, &days,
 					 &percentage)) {
 		return NULL;
 	}
 
-	if (percentage > 100) {
+	if (days < 0 || percentage < 0 || percentage > 100) {
 		PyErr_SetString(PyExc_ValueError,
 			"days must be >= 1, and percentage must be between 1 "
 			"and 100");

--- a/src/py_zfs_pool.c
+++ b/src/py_zfs_pool.c
@@ -35,6 +35,9 @@ void py_zfs_pool_dealloc(py_zfs_pool_t *self) {
 	Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
+PyDoc_STRVAR(py_zfs_pool_name__doc__,
+"Returns the name of ZFS Pool.\n"
+);
 static
 PyObject *py_zfs_pool_get_name(py_zfs_pool_t *self, void *extra) {
 	if (self == NULL)
@@ -47,6 +50,17 @@ PyObject *py_zfs_pool_asdict(PyObject *self, PyObject *args) {
 	Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(py_zfs_pool_root_dataset__doc__,
+"root_dataset(*) -> ZFSDataset\n\n"
+"-----------------\n\n"
+"Returns the ZFSDataset type object for root Dataset of the pool.\n\n"
+"Parameters\n"
+"----------\n"
+"None\n\n"
+"Returns\n"
+"-------\n"
+"None\n\n"
+);
 static
 PyObject *py_zfs_pool_root_dataset(PyObject *self, PyObject *args) {
 	PyObject *out = NULL;
@@ -82,6 +96,17 @@ PyObject *py_zfs_pool_root_dataset(PyObject *self, PyObject *args) {
 	return (out);
 }
 
+PyDoc_STRVAR(py_zfs_pool_root_vdev__doc__,
+"root_vdev(*) -> ZFSVdev\n\n"
+"-----------------------\n\n"
+"Returns the ZFSVdev type object for root VDEV of the pool.\n\n"
+"Parameters\n"
+"----------\n"
+"None\n\n"
+"Returns\n"
+"-------\n"
+"None\n\n"
+);
 static
 PyObject *py_zfs_pool_root_vdev(PyObject *self, PyObject *args) {
 	PyObject *out = NULL;
@@ -102,6 +127,21 @@ PyObject *py_zfs_pool_root_vdev(PyObject *self, PyObject *args) {
 	return (out);
 }
 
+PyDoc_STRVAR(py_zfs_pool_clear__doc__,
+"clear(*) -> None\n\n"
+"----------------\n\n"
+"Clear device errors in the pool.\n\n"
+"Parameters\n"
+"----------\n"
+"None\n\n"
+"Returns\n"
+"-------\n"
+"None\n\n"
+"Raises:\n"
+"-------\n"
+"truenas_pylibzfs.ZFSError:\n"
+"    A libzfs error that occurred while trying to perform the operation.\n"
+);
 static
 PyObject *py_zfs_pool_clear(PyObject *self, PyObject *args) {
 	int ret = 0;
@@ -138,6 +178,21 @@ PyObject *py_zfs_pool_clear(PyObject *self, PyObject *args) {
 	Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(py_zfs_pool_upgrade__doc__,
+"upgrade(*) -> None\n\n"
+"------------------\n\n"
+"Enables all supported features on the given pool.\n\n"
+"Parameters\n"
+"----------\n"
+"None\n\n"
+"Returns\n"
+"-------\n"
+"None\n\n"
+"Raises:\n"
+"-------\n"
+"truenas_pylibzfs.ZFSError:\n"
+"    A libzfs error that occurred while trying to perform the operation.\n"
+);
 static
 PyObject *py_zfs_pool_upgrade(PyObject *self, PyObject *args) {
 	int ret = 0;
@@ -166,6 +221,22 @@ PyObject *py_zfs_pool_upgrade(PyObject *self, PyObject *args) {
 	Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(py_zfs_pool_delete__doc__,
+"delete(*) -> None\n\n"
+"-----------------\n\n"
+"Destroys the given pool, freeing up any devices for other use.\n\n"
+"Parameters\n"
+"----------\n"
+"force: bool, optional\n"
+"    Forecully unmount all active datasets.\n\n"
+"Returns\n"
+"-------\n"
+"None\n\n"
+"Raises:\n"
+"-------\n"
+"truenas_pylibzfs.ZFSError:\n"
+"    A libzfs error that occurred while trying to perform the operation.\n"
+);
 static
 PyObject *py_zfs_pool_delete(PyObject *self, PyObject *args, PyObject *kwargs) {
 	int ret, force;
@@ -201,6 +272,21 @@ PyObject *py_zfs_pool_delete(PyObject *self, PyObject *args, PyObject *kwargs) {
 	Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(py_zfs_pool_ddt_prefetch__doc__,
+"ddt_prefetch(*) -> None\n\n"
+"-----------------------\n\n"
+"Prefetch data of a specific type (DDT) for given pool.\n\n"
+"Parameters\n"
+"----------\n"
+"None\n\n"
+"Returns\n"
+"-------\n"
+"None\n\n"
+"Raises:\n"
+"-------\n"
+"truenas_pylibzfs.ZFSError:\n"
+"    A libzfs error that occurred while trying to perform the operation.\n"
+);
 static
 PyObject *py_zfs_pool_ddt_prefetch(PyObject *self, PyObject *args) {
 	int ret = 0;
@@ -228,6 +314,27 @@ PyObject *py_zfs_pool_ddt_prefetch(PyObject *self, PyObject *args) {
 	Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(py_zfs_pool_ddt_prune__doc__,
+"ddt_prune(*, [days], [percentage]) -> None\n\n"
+"------------------------------------------\n\n"
+"Prunes the older entries from single reference dedup table(s) to reclaim\n"
+"space under the quota. Only one of days or percentage should be passed.\n\n"
+"Parameters\n"
+"----------\n"
+"days: Int, optional\n"
+"    Prune the entries based on age, i.e. deletes every entry older than N\n"
+"    days. Must be a +ve Integer. -ve values are not allowed.\n\n"
+"percentage: Int, optional\n"
+"    Target percentage of unique entries to be removed. Value must be between\n"
+"    1 to 100. -ve values are not allowed.\n\n"
+"Returns\n"
+"-------\n"
+"None\n\n"
+"Raises:\n"
+"-------\n"
+"truenas_pylibzfs.ZFSError:\n"
+"    A libzfs error that occurred while trying to perform the operation.\n"
+);
 static
 PyObject *py_zfs_pool_ddt_prune(PyObject *self,
 				PyObject *args,
@@ -248,7 +355,8 @@ PyObject *py_zfs_pool_ddt_prune(PyObject *self,
 
 	if (percentage > 100) {
 		PyErr_SetString(PyExc_ValueError,
-			"days must be >= 1, and percentage must be between 1 and 100");
+			"days must be >= 1, and percentage must be between 1 "
+			"and 100");
 	} else if (days > 0 && percentage > 0) {
 		PyErr_SetString(PyExc_ValueError,
 			"Only one of days or percentage should be set");
@@ -289,7 +397,8 @@ PyObject *py_zfs_pool_ddt_prune(PyObject *self,
 PyGetSetDef zfs_pool_getsetters[] = {
 	{
 		.name	= "name",
-		.get	= (getter)py_zfs_pool_get_name
+		.get	= (getter)py_zfs_pool_get_name,
+		.doc	= py_zfs_pool_name__doc__
 	},
 	{ .name = NULL }
 };
@@ -303,37 +412,44 @@ PyMethodDef zfs_pool_methods[] = {
 	{
 		.ml_name = "root_dataset",
 		.ml_meth = py_zfs_pool_root_dataset,
-		.ml_flags = METH_NOARGS
+		.ml_flags = METH_NOARGS,
+		.ml_doc = py_zfs_pool_root_dataset__doc__
 	},
 	{
 		.ml_name = "root_vdev",
 		.ml_meth = py_zfs_pool_root_vdev,
-		.ml_flags = METH_NOARGS
+		.ml_flags = METH_NOARGS,
+		.ml_doc = py_zfs_pool_root_vdev__doc__
 	},
 	{
 		.ml_name = "clear",
 		.ml_meth = py_zfs_pool_clear,
-		.ml_flags = METH_NOARGS
+		.ml_flags = METH_NOARGS,
+		.ml_doc = py_zfs_pool_clear__doc__
 	},
 	{
 		.ml_name = "upgrade",
 		.ml_meth = py_zfs_pool_upgrade,
-		.ml_flags = METH_NOARGS
+		.ml_flags = METH_NOARGS,
+		.ml_doc = py_zfs_pool_upgrade__doc__
 	},
 	{
 		.ml_name = "delete",
 		.ml_meth = (PyCFunction)py_zfs_pool_delete,
-		.ml_flags = METH_VARARGS | METH_KEYWORDS
+		.ml_flags = METH_VARARGS | METH_KEYWORDS,
+		.ml_doc = py_zfs_pool_delete__doc__
 	},
 	{
 		.ml_name = "ddt_prefetch",
 		.ml_meth = py_zfs_pool_ddt_prefetch,
-		.ml_flags = METH_NOARGS
+		.ml_flags = METH_NOARGS,
+		.ml_doc = py_zfs_pool_ddt_prefetch__doc__
 	},
 	{
 		.ml_name = "ddt_prune",
 		.ml_meth = (PyCFunction)py_zfs_pool_ddt_prune,
-		.ml_flags = METH_VARARGS | METH_KEYWORDS
+		.ml_flags = METH_VARARGS | METH_KEYWORDS,
+		.ml_doc = py_zfs_pool_ddt_prune__doc__
 	},
 	{ NULL, NULL, 0, NULL }
 };


### PR DESCRIPTION
This PR adds:
* Audit events and zpool history logs for ZFSPool operations
* Doc strings have been added for ZFSPool methods and attributes
* Fixed an issue in `ddt_prune` operation