### PR TITLE
Add ZFS volume object

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ truenas_pylibzfs = Extension(
         'src/py_zfs_resource.c',
         'src/py_zfs_state.c',
         'src/py_zfs_vdev.c',
+        'src/py_zfs_volume.c',
         'src/truenas_pylibzfs.c',
         'src/utils.c',
     ],

--- a/src/py_zfs.c
+++ b/src/py_zfs.c
@@ -126,7 +126,10 @@ PyObject *py_zfs_resource_open(PyObject *self,
 
 	switch (type) {
 	case ZFS_TYPE_FILESYSTEM:
-		out = (PyObject *)init_zfs_dataset(plz, zfsp);
+		out = (PyObject *)init_zfs_dataset(plz, zfsp, B_FALSE);
+		break;
+	case ZFS_TYPE_VOLUME:
+		out = (PyObject *)init_zfs_volume(plz, zfsp, B_FALSE);
 		break;
 	default:
 		PyErr_SetString(PyExc_RuntimeError,

--- a/src/py_zfs_resource.c
+++ b/src/py_zfs_resource.c
@@ -1,4 +1,5 @@
 #include "truenas_pylibzfs.h"
+#include "py_zfs_iter.h"
 
 #define ZFS_RESOURCE_STR "<" PYLIBZFS_MODULE_NAME \
     ".ZFSResource(name=%U, pool=%U, type=%U)>"
@@ -48,12 +49,120 @@ PyObject *py_zfs_resource_userspace(PyObject *self, PyObject *args) {
 	Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(py_zfs_resource_iter_filesystems__doc__,
+"iter_filesystems(*, callback, state, fast=False) -> bool\n\n"
+"--------------------------------------------------------\n\n"
+"List all child filesystems of this ZFSResource. Arguments are keyword-only\n\n"
+"Parameters\n"
+"----------\n"
+"callback: callable\n"
+"    Callback function that will be called for every child dataset.\n\n"
+"state: object, optional\n"
+"    Optional python object (for example dictionary) passed as an argument\n"
+"    to the callback function for each dataset child.\n\n"
+"fast: bool, optional, default=False\n"
+"    Optional boolean flag to perform faster filesystem iteration.\n"
+"    The speedup is accomplished by generating simple ZFS dataset handles\n"
+"    that do not contain full property information\n\n"
+"Returns\n"
+"-------\n"
+"bool\n"
+"    Value indicates that iteration completed without being stopp by the\n"
+"    callback fuction returning False.\n\n"
+"Raises:\n"
+"-------\n"
+"truenas_pylibzfs.ZFSError:\n"
+"    An error occurred during iteration of the dataset. Note that this\n"
+"    exception type may also be raised within the callback function.\n\n"
+"NOTE regarding \"callback\":\n"
+"--------------------------\n"
+"Minimally the function signature must take a single argument for each ZFS\n"
+"object. If the \"state\" keyword is specified then the callback function\n"
+"should take two arguments. The callback function must return bool value\n"
+"indicating whether iteration should continue.\n\n"
+"Example \"callback\":\n"
+"-------------------\n"
+"def my_callback(ds, state):\n"
+"    print(f'{ds.name}: {state}')\n"
+"    return True\n"
+);
+static
+PyObject *py_zfs_resource_iter_filesystems(PyObject *self,
+					   PyObject *args_unused,
+					   PyObject *kwargs)
+{
+	int err;
+	py_zfs_resource_t *rsrc = (py_zfs_resource_t *)self;
+	py_zfs_obj_t *obj = &rsrc->obj;
+
+	py_iter_state_t iter_state = (py_iter_state_t){
+		.pylibzfsp = obj->pylibzfsp,
+		.target = obj->zhp
+	};
+	int simple_handle = 0;
+
+	char *kwnames [] = {
+		"callback",
+		"state",
+		"fast",
+		NULL
+	};
+
+	if (!PyArg_ParseTupleAndKeywords(args_unused, kwargs,
+					 "|$OOp",
+					 kwnames,
+					 &iter_state.callback_fn,
+					 &iter_state.private_data,
+					 &simple_handle)) {
+		return NULL;
+	}
+
+	if (!iter_state.callback_fn) {
+		PyErr_SetString(PyExc_ValueError,
+				"`callback` keyword argument is required.");
+		return NULL;
+	}
+
+	if (!PyCallable_Check(iter_state.callback_fn)) {
+		PyErr_SetString(PyExc_TypeError,
+				"callback function must be callable.");
+		return NULL;
+	}
+
+	if (PySys_Audit(PYLIBZFS_MODULE_NAME ".ZFSResource.iter_filesystems",
+			"OO", obj->name, kwargs) < 0) {
+		return NULL;
+	}
+
+	if (simple_handle) {
+		iter_state.iter_config.filesystem.flags |= ZFS_ITER_SIMPLE;
+	}
+
+	err = py_iter_filesystems(&iter_state);
+	if ((err == ITER_RESULT_ERROR) || (err == ITER_RESULT_IOCTL_ERROR)) {
+		// Exception is set by callback function
+		return NULL;
+	}
+
+	if (err == ITER_RESULT_SUCCESS) {
+		Py_RETURN_TRUE;
+	}
+
+	Py_RETURN_FALSE;
+}
+
 static
 PyMethodDef zfs_resource_methods[] = {
 	{
 		.ml_name = "get_dependents",
 		.ml_meth = py_zfs_resource_get_dependents,
 		.ml_flags = METH_VARARGS
+	},
+	{
+		.ml_name = "iter_filesystems",
+		.ml_meth = (PyCFunction)py_zfs_resource_iter_filesystems,
+		.ml_flags = METH_VARARGS | METH_KEYWORDS,
+		.ml_doc = py_zfs_resource_iter_filesystems__doc__
 	},
 	{
 		.ml_name = "update_properties",

--- a/src/py_zfs_volume.c
+++ b/src/py_zfs_volume.c
@@ -1,80 +1,70 @@
 #include "truenas_pylibzfs.h"
 #include "py_zfs_iter.h"
 
-#define ZFS_DATASET_STR "<" PYLIBZFS_MODULE_NAME \
-    ".ZFSDataset(name=%U, pool=%U, type=%U)>"
+#define ZFS_VOLUME_STR "<" PYLIBZFS_MODULE_NAME \
+    ".ZFSVolume(name=%U, pool=%U, type=%U)>"
 
 static
-PyObject *py_zfs_dataset_new(PyTypeObject *type, PyObject *args,
+PyObject *py_zfs_volume_new(PyTypeObject *type, PyObject *args,
     PyObject *kwds) {
-	py_zfs_dataset_t *self = NULL;
-	self = (py_zfs_dataset_t *)type->tp_alloc(type, 0);
+	py_zfs_volume_t *self = NULL;
+	self = (py_zfs_volume_t *)type->tp_alloc(type, 0);
 	return ((PyObject *)self);
 }
 
 static
-int py_zfs_dataset_init(PyObject *type, PyObject *args, PyObject *kwds) {
+int py_zfs_volume_init(PyObject *type, PyObject *args, PyObject *kwds) {
 	return (0);
 }
 
 static
-void py_zfs_dataset_dealloc(py_zfs_dataset_t *self) {
+void py_zfs_volume_dealloc(py_zfs_volume_t *self) {
 	free_py_zfs_obj(RSRC_TO_ZFS(self));
 	Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
 static
-PyObject *py_zfs_dataset_as_dict(PyObject *self, PyObject *args) {
-	Py_RETURN_NONE;
-}
-
-static
-PyObject *py_repr_zfs_dataset(PyObject *self)
+PyObject *py_repr_zfs_volume(PyObject *self)
 {
-	py_zfs_dataset_t *ds = (py_zfs_dataset_t *)self;
+	py_zfs_volume_t *ds = (py_zfs_volume_t *)self;
 
-	return py_repr_zfs_obj_impl(RSRC_TO_ZFS(ds), ZFS_DATASET_STR);
+	return py_repr_zfs_obj_impl(RSRC_TO_ZFS(ds), ZFS_VOLUME_STR);
 }
 
 static
-PyGetSetDef zfs_dataset_getsetters[] = {
+PyGetSetDef zfs_volume_getsetters[] = {
 	{ .name = NULL }
 };
 
 static
-PyMethodDef zfs_dataset_methods[] = {
-	{
-		.ml_name = "asdict",
-		.ml_meth = py_zfs_dataset_as_dict,
-		.ml_flags = METH_VARARGS
-	},
+PyMethodDef zfs_volume_methods[] = {
 	{ NULL, NULL, 0, NULL }
 };
 
-PyTypeObject ZFSDataset = {
-	.tp_name = PYLIBZFS_MODULE_NAME ".ZFSDataset",
-	.tp_basicsize = sizeof (py_zfs_dataset_t),
-	.tp_methods = zfs_dataset_methods,
-	.tp_getset = zfs_dataset_getsetters,
-	.tp_new = py_zfs_dataset_new,
-	.tp_init = py_zfs_dataset_init,
-	.tp_doc = "ZFSDataset",
-	.tp_dealloc = (destructor)py_zfs_dataset_dealloc,
-	.tp_repr = py_repr_zfs_dataset,
+PyTypeObject ZFSVolume = {
+	.tp_name = PYLIBZFS_MODULE_NAME ".ZFSVolume",
+	.tp_basicsize = sizeof (py_zfs_volume_t),
+	.tp_methods = zfs_volume_methods,
+	.tp_getset = zfs_volume_getsetters,
+	.tp_new = py_zfs_volume_new,
+	.tp_init = py_zfs_volume_init,
+	.tp_doc = "ZFSVolume",
+	.tp_dealloc = (destructor)py_zfs_volume_dealloc,
+	.tp_repr = py_repr_zfs_volume,
 	.tp_flags = Py_TPFLAGS_DEFAULT,
 	.tp_base = &ZFSResource
 };
 
-py_zfs_dataset_t *init_zfs_dataset(py_zfs_t *lzp, zfs_handle_t *zfsp, boolean_t simple)
+py_zfs_volume_t *init_zfs_volume(py_zfs_t *lzp, zfs_handle_t *zfsp, boolean_t simple)
 {
-	py_zfs_dataset_t *out = NULL;
+	py_zfs_volume_t *out = NULL;
 	py_zfs_obj_t *obj = NULL;
 	const char *ds_name;
 	const char *pool_name;
 	zfs_type_t zfs_type;
 	uint64_t guid, createtxg;
 
-	out = (py_zfs_dataset_t *)PyObject_CallFunction((PyObject *)&ZFSDataset, NULL);
+	out = (py_zfs_volume_t *)PyObject_CallFunction((PyObject *)&ZFSVolume, NULL);
 	if (out == NULL) {
 		return NULL;
 	}
@@ -90,6 +80,8 @@ py_zfs_dataset_t *init_zfs_dataset(py_zfs_t *lzp, zfs_handle_t *zfsp, boolean_t 
 	guid = zfs_prop_get_int(zfsp, ZFS_PROP_GUID);
 	createtxg = zfs_prop_get_int(zfsp, ZFS_PROP_CREATETXG);
 	Py_END_ALLOW_THREADS
+
+	PYZFS_ASSERT((zfs_type == ZFS_TYPE_VOLUME), "Incorrect ZFS dataset type");
 
 	obj->name = PyUnicode_FromString(ds_name);
 	if (obj->name == NULL)

--- a/src/truenas_pylibzfs.c
+++ b/src/truenas_pylibzfs.c
@@ -7,6 +7,7 @@ static PyTypeObject *alltypes[] = {
 	&ZFSPool,
 	&ZFSProperty,
 	&ZFSVdev,
+	&ZFSVolume,
 	NULL
 };
 

--- a/src/truenas_pylibzfs.h
+++ b/src/truenas_pylibzfs.h
@@ -147,6 +147,7 @@ extern PyTypeObject ZFSPool;
 extern PyTypeObject ZFSProperty;
 extern PyTypeObject ZFSResource;
 extern PyTypeObject ZFSVdev;
+extern PyTypeObject ZFSVolume;
 
 /*
  * Provided by error.c
@@ -240,13 +241,22 @@ extern void _set_exc_from_libzfs(py_zfs_error_t *err,
  *		resulting ZFSDataset object owns the handle and it must not
  *		be closed or manipulated in other ways.
  *
+ * @param[in]	simple - indicates whether the underlying dataset was created
+ *		as a simple handle (properties not available).
+ *
  * @return	returns pointer to new ZFSDataset object. NULL on failure.
  *
  * NOTE: if this call fails, onus is on caller to zfs_close() zfsp if required.
  *
  * GIL must be held when this is called.
  */
-extern py_zfs_dataset_t *init_zfs_dataset(py_zfs_t *lzp, zfs_handle_t *zfsp);
+extern py_zfs_dataset_t *init_zfs_dataset(py_zfs_t *lzp, zfs_handle_t *zfsp,
+					  boolean_t simple);
+
+/* Provided by py_zfs_volume.c */
+/* Caveats and parameters are same as init_zfs_dataset() above */
+extern py_zfs_volume_t *init_zfs_volume(py_zfs_t *lzp, zfs_handle_t *zfsp,
+					boolean_t simple);
 
 /* Provided by py_zfs_pool.c */
 extern py_zfs_pool_t *init_zfs_pool(py_zfs_t *lzp, zpool_handle_t *zhp);


### PR DESCRIPTION
This commit python definitions for zvols and shifts the filesystem iterator to the parent ZFS resource type for datasets and zvols to avoid code duplication.