### PR TITLE
Add ability to get / set user properties

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ truenas_pylibzfs = Extension(
         'src/truenas_pylibzfs.c',
         'src/truenas_pylibzfs_state.c',
         'src/utils.c',
+        'src/nvlist_utils.c',
         'src/libzfs/py_zfs.c',
         'src/libzfs/py_zfs_dataset.c',
         'src/libzfs/py_zfs_enum.c',

--- a/src/nvlist_utils.c
+++ b/src/nvlist_utils.c
@@ -1,0 +1,99 @@
+#include "truenas_pylibzfs.h"
+
+/*
+ * This function converts the nvlist containing user props
+ * into a python dictionary of form:
+ * {"<nvpair_name>": "<nvpair_value_string"}
+ */
+PyObject *user_props_nvlist_to_py_dict(nvlist_t *userprops)
+{
+	PyObject *d = NULL;
+	nvpair_t *elem;
+
+	d = PyDict_New();
+	if (d == NULL)
+		return NULL;
+
+	for (elem = nvlist_next_nvpair(userprops, NULL);
+	    elem != NULL;
+	    elem = nvlist_next_nvpair(userprops, elem)) {
+		const char *name = nvpair_name(elem);
+		const char *cval;
+		nvlist_t *nvl;
+
+		PYZFS_ASSERT(
+			(nvpair_type(elem) == DATA_TYPE_NVLIST),
+			"Unexpected nvpair data type in user props"
+
+		);
+
+		nvl = fnvpair_value_nvlist(elem);
+		cval = fnvlist_lookup_string(nvl, ZPROP_VALUE);
+
+		PyObject *val = PyUnicode_FromString(cval);
+		if (val == NULL) {
+			Py_DECREF(d);
+			return NULL;
+		}
+
+		if (PyDict_SetItemString(d, name, val) < 0)  {
+			Py_DECREF(d);
+			Py_DECREF(val);
+			return NULL;
+		}
+
+		Py_DECREF(val);
+	}
+
+	return d;
+}
+
+/*
+ * Convert a python dictionary of user props into an nvlist
+ * for insertion as user properties.
+ */
+nvlist_t *py_userprops_dict_to_nvlist(PyObject *pyprops)
+{
+	nvlist_t *nvl = fnvlist_alloc();
+	PyObject *key, *value;
+	Py_ssize_t pos = 0;
+
+	while (PyDict_Next(pyprops, &pos, &key, &value)) {
+		const char *name = NULL;
+		const char *cval = NULL;
+
+		name = PyUnicode_AsUTF8(key);
+		if (name == NULL) {
+			fnvlist_free(nvl);
+			return NULL;
+		}
+
+		if (strstr(name, ":") == NULL) {
+			PyErr_Format(PyExc_ValueError,
+				     "%s: user properties must "
+				     "contain a colon (:) in their "
+				     "name.", name);
+
+			fnvlist_free(nvl);
+			return NULL;
+		} else if (strlen(name) > ZAP_MAXNAMELEN) {
+			PyErr_Format(PyExc_ValueError,
+				     "%s: property name exceeds max "
+				     "length of %d.", name,
+				     ZAP_MAXNAMELEN);
+
+			fnvlist_free(nvl);
+			return NULL;
+		}
+
+		cval = PyUnicode_AsUTF8(value);
+		if (cval == NULL) {
+			fnvlist_free(nvl);
+			return NULL;
+		}
+
+		fnvlist_add_string(nvl, name, cval);
+	}
+
+	return nvl;
+}

--- a/src/truenas_pylibzfs.h
+++ b/src/truenas_pylibzfs.h
@@ -387,4 +387,8 @@ extern PyObject *py_zfs_get_properties(py_zfs_obj_t *pyzfs,
 				       boolean_t get_source);
 
 extern PyObject *py_zfs_props_to_dict(py_zfs_obj_t *pyzfs, PyObject *pyprops);
+
+/* Provided by nvlist_utils.c */
+extern PyObject *user_props_nvlist_to_py_dict(nvlist_t *userprops);
+extern nvlist_t *py_userprops_dict_to_nvlist(PyObject *pyprops);
 #endif  /* _TRUENAS_PYLIBZFS_H */


### PR DESCRIPTION
This commit adds basic functionality to get and set ZFS user properties. These are treated exposed separately from regular ZFS properties for performance and convenience reasons. get_user_properties is also plumbed into the asdict() method for ZFS resources.