### PR TITLE
Add ZFSSnapshot type and allow opening it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ truenas_pylibzfs = Extension(
         'src/libzfs/py_zfs_pool.c',
         'src/libzfs/py_zfs_prop.c',
         'src/libzfs/py_zfs_resource.c',
+        'src/libzfs/py_zfs_snapshot.c',
         'src/libzfs/py_zfs_vdev.c',
         'src/libzfs/py_zfs_volume.c',
         'src/libzfs_core/py_zfs_core_module.c',

--- a/src/libzfs/py_zfs.c
+++ b/src/libzfs/py_zfs.c
@@ -64,10 +64,6 @@ void py_zfs_dealloc(py_zfs_t *self) {
 	Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
-PyObject *py_zfs_get_proptypes(py_zfs_prop_t *self, void *extra) {
-	Py_RETURN_NONE;
-}
-
 PyObject *py_zfs_asdict(PyObject *self, PyObject *args) {
 	Py_RETURN_NONE;
 }
@@ -128,6 +124,9 @@ PyObject *py_zfs_resource_open(PyObject *self,
 		break;
 	case ZFS_TYPE_VOLUME:
 		out = (PyObject *)init_zfs_volume(plz, zfsp, B_FALSE);
+		break;
+	case ZFS_TYPE_SNAPSHOT:
+		out = (PyObject *)init_zfs_snapshot(plz, zfsp, B_FALSE);
 		break;
 	default:
 		PyErr_SetString(PyExc_RuntimeError,
@@ -196,10 +195,6 @@ PyObject *py_zfs_pool_open(PyObject *self,
 }
 
 PyGetSetDef zfs_getsetters[] = {
-	{
-		.name	= "proptypes",
-		.get	= (getter)py_zfs_get_proptypes
-	},
 	{ .name = NULL }
 };
 

--- a/src/libzfs/py_zfs_snapshot.c
+++ b/src/libzfs/py_zfs_snapshot.c
@@ -1,0 +1,111 @@
+#include "../truenas_pylibzfs.h"
+#include "py_zfs_iter.h"
+
+#define ZFS_SNAP_STR "<" PYLIBZFS_MODULE_NAME \
+    ".ZFSSnapshot(name=%U, pool=%U, type=%U)>"
+
+static
+PyObject *py_zfs_snapshot_new(PyTypeObject *type, PyObject *args,
+    PyObject *kwds) {
+	py_zfs_snapshot_t *self = NULL;
+	self = (py_zfs_snapshot_t *)type->tp_alloc(type, 0);
+	return ((PyObject *)self);
+}
+
+static
+int py_zfs_snapshot_init(PyObject *type, PyObject *args, PyObject *kwds) {
+	return (0);
+}
+
+static
+void py_zfs_snapshot_dealloc(py_zfs_snapshot_t *self) {
+	free_py_zfs_obj(RSRC_TO_ZFS(self));
+	Py_TYPE(self)->tp_free((PyObject *)self);
+}
+
+static
+PyObject *py_repr_zfs_snapshot(PyObject *self)
+{
+	py_zfs_snapshot_t *ds = (py_zfs_snapshot_t *)self;
+
+	return py_repr_zfs_obj_impl(RSRC_TO_ZFS(ds), ZFS_SNAP_STR);
+}
+
+static
+PyGetSetDef zfs_snapshot_getsetters[] = {
+	{ .name = NULL }
+};
+
+static
+PyMethodDef zfs_snapshot_methods[] = {
+	{ NULL, NULL, 0, NULL }
+};
+
+PyTypeObject ZFSSnapshot = {
+	.tp_name = PYLIBZFS_MODULE_NAME ".ZFSSnapshot",
+	.tp_basicsize = sizeof (py_zfs_snapshot_t),
+	.tp_methods = zfs_snapshot_methods,
+	.tp_getset = zfs_snapshot_getsetters,
+	.tp_new = py_zfs_snapshot_new,
+	.tp_init = py_zfs_snapshot_init,
+	.tp_doc = "ZFSSnapshot",
+	.tp_dealloc = (destructor)py_zfs_snapshot_dealloc,
+	.tp_repr = py_repr_zfs_snapshot,
+	.tp_flags = Py_TPFLAGS_DEFAULT,
+	.tp_base = &ZFSResource
+};
+
+py_zfs_snapshot_t *init_zfs_snapshot(py_zfs_t *lzp, zfs_handle_t *zfsp, boolean_t simple)
+{
+	py_zfs_snapshot_t *out = NULL;
+	py_zfs_obj_t *obj = NULL;
+	const char *ds_name;
+	const char *pool_name;
+	zfs_type_t zfs_type;
+	uint64_t guid, createtxg;
+
+	out = (py_zfs_snapshot_t *)PyObject_CallFunction((PyObject *)&ZFSSnapshot, NULL);
+	if (out == NULL) {
+		return NULL;
+	}
+	out->rsrc.is_simple = simple;
+	obj = RSRC_TO_ZFS(out);
+	obj->pylibzfsp = lzp;
+	Py_INCREF(lzp);
+
+	Py_BEGIN_ALLOW_THREADS
+	ds_name = zfs_get_name(zfsp);
+	zfs_type = zfs_get_type(zfsp);
+	pool_name = zfs_get_pool_name(zfsp);
+	guid = zfs_prop_get_int(zfsp, ZFS_PROP_GUID);
+	createtxg = zfs_prop_get_int(zfsp, ZFS_PROP_CREATETXG);
+	Py_END_ALLOW_THREADS
+
+	PYZFS_ASSERT((zfs_type == ZFS_TYPE_SNAPSHOT), "Incorrect ZFS type");
+
+	obj->name = PyUnicode_FromString(ds_name);
+	if (obj->name == NULL)
+		goto error;
+
+	obj->pool_name = PyUnicode_FromString(pool_name);
+	if (obj->pool_name == NULL)
+		goto error;
+
+	obj->ctype = zfs_type;
+	obj->type_enum = py_get_zfs_type(lzp, zfs_type, &obj->type);
+	obj->guid = Py_BuildValue("k", guid);
+	if (obj->guid == NULL)
+		goto error;
+
+	obj->createtxg = Py_BuildValue("k", createtxg);
+	if (obj->createtxg == NULL)
+		goto error;
+
+	obj->zhp = zfsp;
+	return out;
+
+error:
+	// This deallocates the new object and decrements refcnt on pylibzfsp
+	Py_DECREF(out);
+	return NULL;
+}

--- a/src/truenas_pylibzfs.c
+++ b/src/truenas_pylibzfs.c
@@ -5,6 +5,7 @@ static PyTypeObject *alltypes[] = {
 	&ZFSDataset,
 	&ZFSObject,
 	&ZFSPool,
+	&ZFSSnapshot,
 	&ZFSVdev,
 	&ZFSVolume,
 	NULL

--- a/src/truenas_pylibzfs.h
+++ b/src/truenas_pylibzfs.h
@@ -6,7 +6,8 @@
 #include "truenas_pylibzfs_core.h"
 
 #define PYLIBZFS_MODULE_NAME "truenas_pylibzfs"
-#define SUPPORTED_RESOURCES ZFS_TYPE_VOLUME | ZFS_TYPE_FILESYSTEM
+#define SUPPORTED_RESOURCES ZFS_TYPE_VOLUME | ZFS_TYPE_FILESYSTEM | \
+	ZFS_TYPE_SNAPSHOT
 #define MAX_HISTORY_PREFIX_LEN 25
 
 /*
@@ -104,7 +105,6 @@ typedef struct {
 
 typedef struct {
 	py_zfs_resource_t rsrc;
-	PyObject *snapshot_name;
 } py_zfs_snapshot_t;
 
 /* Macro to get pointer to base ZFS object from various ZFS resource types */
@@ -126,27 +126,12 @@ typedef struct {
 	PyObject *path;
 } py_zfs_vdev_t;
 
-typedef struct {
-	PyObject_HEAD
-	int propid;
-	const char *cname;
-	char cvalue[ZFS_MAXPROPLEN + 1];
-	char crawvalue[ZFS_MAXPROPLEN + 1];
-	char csrcstr[ZFS_MAXPROPLEN + 1];
-	zprop_source_t csource;
-} py_zfs_prop_t;
-
-typedef struct {
-	py_zfs_prop_t super;
-	PyObject *values;
-	const char *name;
-} py_zfs_user_prop_t;
-
 extern PyTypeObject ZFS;
 extern PyTypeObject ZFSDataset;
 extern PyTypeObject ZFSObject;
 extern PyTypeObject ZFSPool;
 extern PyTypeObject ZFSResource;
+extern PyTypeObject ZFSSnapshot;
 extern PyTypeObject ZFSVdev;
 extern PyTypeObject ZFSVolume;
 
@@ -260,6 +245,11 @@ extern py_zfs_dataset_t *init_zfs_dataset(py_zfs_t *lzp, zfs_handle_t *zfsp,
 /* Caveats and parameters are same as init_zfs_dataset() above */
 extern py_zfs_volume_t *init_zfs_volume(py_zfs_t *lzp, zfs_handle_t *zfsp,
 					boolean_t simple);
+
+/* Provided by py_zfs_snapshot.c */
+/* Caveats and parameters are same as init_zfs_dataset() above */
+extern py_zfs_snapshot_t *init_zfs_snapshot(py_zfs_t *lzp, zfs_handle_t *zfsp,
+					    boolean_t simple);
 
 /* Provided by py_zfs_pool.c */
 extern py_zfs_pool_t *init_zfs_pool(py_zfs_t *lzp, zpool_handle_t *zhp);


### PR DESCRIPTION
This commit adds basic functionality to open a ZFS snapshot. At this point no type methods or getsetters are defined.