### PR TITLE
Add iter_snapshots method for ZFSResource

### DIFF
--- a/src/libzfs/py_zfs_iter.h
+++ b/src/libzfs/py_zfs_iter.h
@@ -19,7 +19,7 @@ typedef struct {
 
 typedef struct {
 	int flags;
-	int sorted;
+	boolean_t sorted;
 	uint64_t min_txg;
 	uint64_t max_txg;
 } iter_conf_snapshot_t;
@@ -63,8 +63,6 @@ typedef struct {
 } py_iter_state_t;
 
 extern int py_iter_filesystems(py_iter_state_t *state);
-#if 0
 extern int py_iter_snapshots(py_iter_state_t *state);
-#endif
 
 #endif  /* _PY_ZFS_ITER_H */

--- a/src/libzfs/py_zfs_resource.c
+++ b/src/libzfs/py_zfs_resource.c
@@ -151,8 +151,126 @@ PyObject *py_zfs_resource_iter_filesystems(PyObject *self,
 	Py_RETURN_FALSE;
 }
 
+PyDoc_STRVAR(py_zfs_resource_iter_snapshots__doc__,
+"iter_snapshots(*, callback, state, fast=False,\n"
+"               min_transaction_group=0,\n"
+"               max_transaction_group=0,\n"
+"               order_by_transaction_group=False) -> bool\n"
+"--------------------------------------------------------\n\n"
+"List all snapshots of this ZFSResource. Arguments are keyword-only\n\n"
+"Parameters\n"
+"----------\n"
+"callback: callable\n"
+"    Callback function that will be called for every child dataset.\n\n"
+"state: object, optional\n"
+"    Optional python object (for example dictionary) passed as an argument\n"
+"    to the callback function for each dataset child.\n\n"
+"fast: bool, optional, default=False\n"
+"    Optional boolean flag to perform faster filesystem iteration.\n"
+"    The speedup is accomplished by generating simple ZFS dataset handles\n"
+"    that do not contain full property information\n\n"
+"min_transaction_group: int, optional\n"
+"    Only include snapshots newer than the specified transaction group\n\n"
+"max_transaction_group: int, optional\n"
+"    Only include snapshots older than the specified transaction group\n\n"
+"order_by_transaction_group: bool, optional, default=False\n"
+"    Pre-sort the snapshots by transaction group prior to calling\n"
+"    the specified callback function\n\n"
+"Returns\n"
+"-------\n"
+"bool\n"
+"    Value indicates that iteration completed without being stopped by the\n"
+"    callback fuction returning False.\n\n"
+"Raises:\n"
+"-------\n"
+"truenas_pylibzfs.ZFSError:\n"
+"    An error occurred during iteration of the dataset. Note that this\n"
+"    exception type may also be raised within the callback function.\n\n"
+"NOTE regarding \"callback\":\n"
+"--------------------------\n"
+"Minimally the function signature must take a single argument for each ZFS\n"
+"object. If the \"state\" keyword is specified then the callback function\n"
+"should take two arguments. The callback function must return bool value\n"
+"indicating whether iteration should continue.\n\n"
+"Example \"callback\":\n"
+"-------------------\n"
+"def my_callback(ds, state):\n"
+"    print(f'{ds.name}: {state}')\n"
+"    return True\n"
+);
+static
+PyObject *py_zfs_resource_iter_snapshots(PyObject *self,
+					 PyObject *args_unused,
+					 PyObject *kwargs)
+{
+	int err;
+	py_zfs_resource_t *rsrc = (py_zfs_resource_t *)self;
+	py_zfs_obj_t *obj = &rsrc->obj;
+	boolean_t simple_handle = B_FALSE;
+
+	py_iter_state_t iter_state = (py_iter_state_t){
+		.pylibzfsp = obj->pylibzfsp,
+		.target = obj->zhp
+	};
+
+	char *kwnames [] = {
+		"callback",
+		"state",
+		"fast",
+		"min_transaction_group",
+		"max_transaction_group",
+		"order_by_transaction_group",
+		NULL
+	};
+
+	if (!PyArg_ParseTupleAndKeywords(args_unused, kwargs,
+					 "|$OOpkkp",
+					 kwnames,
+					 &iter_state.callback_fn,
+					 &iter_state.private_data,
+					 &simple_handle,
+					 &iter_state.iter_config.snapshot.min_txg,
+					 &iter_state.iter_config.snapshot.max_txg,
+					 &iter_state.iter_config.snapshot.sorted)) {
+		return NULL;
+	}
+
+	if (!iter_state.callback_fn) {
+		PyErr_SetString(PyExc_ValueError,
+				"`callback` keyword argument is required.");
+		return NULL;
+	}
+
+	if (!PyCallable_Check(iter_state.callback_fn)) {
+		PyErr_SetString(PyExc_TypeError,
+				"callback function must be callable.");
+		return NULL;
+	}
+
+	if (PySys_Audit(PYLIBZFS_MODULE_NAME ".ZFSResource.iter_snapshots",
+			"OO", obj->name, kwargs) < 0) {
+		return NULL;
+	}
+
+	if (simple_handle) {
+		iter_state.iter_config.filesystem.flags |= ZFS_ITER_SIMPLE;
+	}
+
+	err = py_iter_snapshots(&iter_state);
+	if ((err == ITER_RESULT_ERROR) || (err == ITER_RESULT_IOCTL_ERROR)) {
+		// Exception is set by callback function
+		return NULL;
+	}
+
+	if (err == ITER_RESULT_SUCCESS) {
+		Py_RETURN_TRUE;
+	}
+
+	Py_RETURN_FALSE;
+}
+
 PyDoc_STRVAR(py_zfs_resource_get_properties__doc__,
-"asdict(*, properties, get_source=False) -> "
+"asdict(*, properties, get_source=False) ->"
 "truenas_pylibzfs.struct_zfs_property\n\n"
 "-------------------------------------\n\n"
 "Get the specified properties of a given ZFS resource.\n\n"
@@ -493,6 +611,12 @@ PyMethodDef zfs_resource_methods[] = {
 		.ml_meth = (PyCFunction)py_zfs_resource_iter_filesystems,
 		.ml_flags = METH_VARARGS | METH_KEYWORDS,
 		.ml_doc = py_zfs_resource_iter_filesystems__doc__
+	},
+	{
+		.ml_name = "iter_snapshots",
+		.ml_meth = (PyCFunction)py_zfs_resource_iter_snapshots,
+		.ml_flags = METH_VARARGS | METH_KEYWORDS,
+		.ml_doc = py_zfs_resource_iter_snapshots__doc__
 	},
 	{
 		.ml_name = "update_properties",


### PR DESCRIPTION
This commit adds a new type method for ZFSResource types to iterate snapshots. Various parameters are supported:

- fast: retrieve simple zfs_handle_t handles with only basic information.

- min_transaction_group, max_transaction_group: slice a range of snapshots for iteration.

- sorted: have libzfs pre-sort prior to calling back into python