### PR TITLE
Add method to get clones of ZFS snapshot

### DIFF
--- a/src/nvlist_utils.c
+++ b/src/nvlist_utils.c
@@ -97,3 +97,34 @@ nvlist_t *py_userprops_dict_to_nvlist(PyObject *pyprops)
 
 	return nvl;
 }
+
+PyObject *py_nvlist_names_tuple(nvlist_t *nvl)
+{
+	PyObject *l = NULL;
+	PyObject *out = NULL;
+	nvpair_t *elem;
+
+	l = PyList_New(0);
+	if (l == NULL)
+		return NULL;
+
+	for (elem = nvlist_next_nvpair(nvl, NULL); elem != NULL;
+	    elem = nvlist_next_nvpair(nvl, elem)) {
+		PyObject *name = PyUnicode_FromString(nvpair_name(elem));
+		if (name == NULL) {
+			Py_DECREF(l);
+			return NULL;
+		}
+
+		if (PyList_Append(l, name) < 0) {
+			Py_DECREF(name);
+			Py_DECREF(l);
+			return NULL;
+		}
+		Py_DECREF(name);
+	}
+
+	out = PyList_AsTuple(l);
+	Py_DECREF(l);
+	return out;
+}

--- a/src/truenas_pylibzfs.h
+++ b/src/truenas_pylibzfs.h
@@ -383,4 +383,5 @@ extern PyObject *py_zfs_props_to_dict(py_zfs_obj_t *pyzfs, PyObject *pyprops);
 /* Provided by nvlist_utils.c */
 extern PyObject *user_props_nvlist_to_py_dict(nvlist_t *userprops);
 extern nvlist_t *py_userprops_dict_to_nvlist(PyObject *pyprops);
+extern PyObject *py_nvlist_names_tuple(nvlist_t *nvl);
 #endif  /* _TRUENAS_PYLIBZFS_H */


### PR DESCRIPTION
This commit adds type method for ZFSSnapshot type to get the clones of the snapshot. Type returned is always a tuple.

```
>>> import truenas_pylibzfs
>>> z = truenas_pylibzfs.open_handle()
>>> rsrc = z.open_resource(name="dozer/myzv@now")
>>> rsrc.get_clones()
('dozer/newzv',)
```