### PR TITLE
Add some pre-defined property sets

### DIFF
--- a/examples/get_space_stats.py
+++ b/examples/get_space_stats.py
@@ -1,0 +1,42 @@
+# This code snippet provides an example of how to use ZFS iterators
+# to retrieve space information on ZFS resources
+#
+
+import truenas_pylibzfs
+
+DATASETS = ('dozer/MANY', 'dozer/share')
+SPACE_PROPS = truenas_pylibzfs.property_sets.ZFS_SPACE_PROPERTIES
+
+
+def gather_stats(hdl, stats):
+    properties = hdl.get_properties(properties=SPACE_PROPS)
+    stats[hdl.name] = properties
+    return True
+
+
+def gather_stats_dict(hdl, stats):
+    properties = hdl.asdict(properties=SPACE_PROPS)['properties']
+    stats[hdl.name] = properties
+    return True
+
+
+def take_recursive_space_stats(lz_hdl, datasets, as_dict):
+    stats = {}
+    for dataset_name in datasets:
+        rsrc = lz_hdl.open_resource(name=dataset_name)
+        rsrc.iter_filesystems(
+            callback=gather_stats if not as_dict else gather_stats_dict,
+            state=stats,
+            fast=True
+        )
+
+    return stats
+
+
+lz = truenas_pylibzfs.open_handle()
+
+stats = take_recursive_space_stats(lz, DATASETS, False)
+print(f'stats: {stats}')
+
+stats = take_recursive_space_stats(lz, DATASETS, True)
+print(f'stats: {stats}')

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ truenas_pylibzfs = Extension(
         'src/libzfs/py_zfs_vdev.c',
         'src/libzfs/py_zfs_volume.c',
         'src/libzfs_core/py_zfs_core_module.c',
+        'src/property_sets/py_zfs_prop_sets.c',
     ],
     libraries = [
         'zfs',

--- a/src/libzfs/py_zfs_resource.c
+++ b/src/libzfs/py_zfs_resource.c
@@ -330,7 +330,7 @@ PyObject *py_zfs_resource_get_properties(PyObject *self,
 				"properties keyword is required.");
 		return NULL;
 	}
-	if (!PySet_Check(prop_set)) {
+	if (!PyAnySet_Check(prop_set)) {
 		PyErr_SetString(PyExc_TypeError,
 				"properties must be a python set.");
 		return NULL;
@@ -545,7 +545,7 @@ PyObject *py_zfs_resource_asdict(PyObject *self,
 	if (prop_set != NULL) {
 		PyObject *zfsprops = NULL;
 
-		if (!PySet_Check(prop_set)) {
+		if (!PyAnySet_Check(prop_set)) {
 			PyErr_SetString(PyExc_TypeError,
 					"properties must be a set.");
 			return NULL;

--- a/src/property_sets/py_zfs_prop_sets.c
+++ b/src/property_sets/py_zfs_prop_sets.c
@@ -13,7 +13,7 @@ pylibzfs_propset_t *get_propset_state(PyObject *module)
 	pylibzfs_propset_t *state = NULL;
 
 	state = (pylibzfs_propset_t *)PyModule_GetState(module);
-	PYZFS_ASSERT(state, "Failed to get propeset module state.");
+	PYZFS_ASSERT(state, "Failed to get propset module state.");
 
 	return state;
 }

--- a/src/property_sets/py_zfs_prop_sets.c
+++ b/src/property_sets/py_zfs_prop_sets.c
@@ -1,0 +1,202 @@
+#include "../truenas_pylibzfs.h"
+typedef struct {
+	PyObject *zfs_space_props;
+	PyObject *zfs_volume_props;
+	PyObject *zfs_filesystem_props;
+	PyObject *readonly_zfs_props;
+} pylibzfs_propset_t;
+
+
+static
+pylibzfs_propset_t *get_propset_state(PyObject *module)
+{
+	pylibzfs_propset_t *state = NULL;
+
+	state = (pylibzfs_propset_t *)PyModule_GetState(module);
+	PYZFS_ASSERT(state, "Failed to get propeset module state.");
+
+	return state;
+}
+
+static int
+py_zfs_propset_module_clear(PyObject *module)
+{
+	pylibzfs_propset_t *state = get_propset_state(module);
+	Py_CLEAR(state->zfs_space_props);
+	Py_CLEAR(state->zfs_volume_props);
+	Py_CLEAR(state->zfs_filesystem_props);
+	Py_CLEAR(state->readonly_zfs_props);
+	return 0;
+}
+
+static void
+py_zfs_propset_module_free(void *module)
+{
+	if (module)
+		py_zfs_propset_module_clear((PyObject *)module);
+}
+
+static
+boolean_t is_space_zfs_prop(zfs_prop_t prop)
+{
+	boolean_t is_space;
+
+	switch (prop) {
+	case ZFS_PROP_AVAILABLE:
+	case ZFS_PROP_USEDSNAP:
+	case ZFS_PROP_WRITTEN:
+	case ZFS_PROP_USEDDS:
+	case ZFS_PROP_USEDREFRESERV:
+	case ZFS_PROP_USEDCHILD:
+	case ZFS_PROP_USED:
+		is_space = B_TRUE;
+		break;
+	default:
+		is_space = B_FALSE;
+		break;
+	};
+
+	return is_space;
+}
+
+static
+boolean_t py_add_zfs_propset(pylibzfs_state_t *pstate,
+			     PyObject *module,
+			     pylibzfs_propset_t *state)
+{
+	PyObject *iterator = PyObject_GetIter(pstate->zfs_property_enum);
+	PyObject *item = NULL;
+	if (iterator == NULL)
+		return B_FALSE;
+
+	state->readonly_zfs_props = PyFrozenSet_New(NULL);
+	if (state->readonly_zfs_props == NULL)
+		return B_FALSE;
+
+	state->zfs_volume_props = PyFrozenSet_New(NULL);
+	if (state->zfs_volume_props == NULL)
+		return B_FALSE;
+
+	state->zfs_filesystem_props = PyFrozenSet_New(NULL);
+	if (state->zfs_filesystem_props == NULL)
+		return B_FALSE;
+
+	state->zfs_space_props = PyFrozenSet_New(NULL);
+	if (state->zfs_space_props == NULL)
+		return B_FALSE;
+
+	/*
+	 * Iterate the ZFS propset enum and build out frozenset
+	 * based on the properties
+	 */
+	while ((item = PyIter_Next(iterator))) {
+		long val = PyLong_AsLong(item);
+		PYZFS_ASSERT((val != -1), "Unexpected value for ZFS property");
+		PYZFS_ASSERT((val < ZFS_NUM_PROPS), "Value exceeds known ZFS props");
+
+		if (zfs_prop_readonly(val) &&
+		    (PySet_Add(state->readonly_zfs_props, item))) {
+			Py_DECREF(item);
+			return B_FALSE;
+		}
+
+		if (zfs_prop_valid_for_type(val, ZFS_TYPE_VOLUME, B_FALSE) &&
+		    (PySet_Add(state->zfs_volume_props, item))) {
+			Py_DECREF(item);
+			return B_FALSE;
+		}
+
+		if (zfs_prop_valid_for_type(val, ZFS_TYPE_FILESYSTEM, B_FALSE) &&
+		    (PySet_Add(state->zfs_filesystem_props, item))) {
+			Py_DECREF(item);
+			return B_FALSE;
+		}
+
+		if (is_space_zfs_prop(val) &&
+		    (PySet_Add(state->zfs_space_props, item))) {
+			Py_DECREF(item);
+			return B_FALSE;
+		}
+
+		Py_DECREF(item);
+	}
+
+	if (PyModule_AddObjectRef(module, "READONLY_ZFS_PROPERTIES",
+	    state->readonly_zfs_props) < 0) {
+		return B_FALSE;
+	}
+
+	if (PyModule_AddObjectRef(module, "ZFS_VOLUME_PROPERTIES",
+	    state->zfs_volume_props) < 0) {
+		return B_FALSE;
+	}
+
+	if (PyModule_AddObjectRef(module, "ZFS_FILESYSTEM_PROPERTIES",
+	    state->zfs_filesystem_props) < 0) {
+		return B_FALSE;
+	}
+
+	if (PyModule_AddObjectRef(module, "ZFS_SPACE_PROPERTIES",
+	    state->zfs_space_props) < 0) {
+		return B_FALSE;
+	}
+
+	return B_TRUE;
+}
+
+static
+boolean_t py_init_propset_state(pylibzfs_state_t *pstate,
+				PyObject *module,
+				pylibzfs_propset_t *state)
+{
+
+	if (!py_add_zfs_propset(pstate, module, state))
+		return B_FALSE;
+
+	return B_TRUE;
+}
+
+PyDoc_STRVAR(py_zfs_propset_module__doc__,
+PYLIBZFS_MODULE_NAME ".propset provides various frozen sets for ZFS and zpool\n"
+"properties for the convenience of API consumers.\n"
+"\n"
+"The following frozen sets are provided\n"
+"- ZFS_READONLY_PROPERTIES: these properties are not valid for setting once the\n"
+"    dataset or volume is created\n"
+"\n"
+"- ZFS_VOLUME_PROPERTIES: these properties are valid for ZFS_TYPE_VOLUME.\n"
+"\n"
+"- ZFS_FILESYSTEM_PROPERTIES: these properties are valid for ZFS_TYPE_FILESYSTEM.\n"
+"\n"
+"- ZFS_SPACE_PROPERTIES: these properties provide the equivalent of the property\n"
+"   set returned by the command \"zfs get space\".\n"
+);
+/* Module structure */
+static struct PyModuleDef truenas_pypropset = {
+	.m_base = PyModuleDef_HEAD_INIT,
+	.m_name = PYLIBZFS_MODULE_NAME ".property_sets",
+	.m_doc = py_zfs_propset_module__doc__,
+	.m_size = sizeof(pylibzfs_propset_t),
+	.m_clear = py_zfs_propset_module_clear,
+	.m_free = py_zfs_propset_module_free,
+};
+
+PyObject *py_setup_propset_module(PyObject *p)
+{
+	pylibzfs_propset_t *state = NULL;
+	pylibzfs_state_t *pstate = (pylibzfs_state_t *)PyModule_GetState(p);
+	if (pstate == NULL)
+		return NULL;
+
+	PyObject *m = PyModule_Create(&truenas_pypropset);
+	if (m == NULL)
+		return NULL;
+
+	state = get_propset_state(m);
+	if (!py_init_propset_state(pstate, m, state)) {
+		Py_DECREF(m);
+		return NULL;
+	}
+
+	return m;
+}

--- a/src/truenas_pylibzfs.c
+++ b/src/truenas_pylibzfs.c
@@ -150,63 +150,63 @@ PyInit_truenas_pylibzfs(void)
 	PyObject *zfs_exc;
 	PyObject *constants = NULL;
 	PyObject *lzc = NULL;
+	PyObject *propsets = NULL;
+	int err;
 
 	PyObject *mpylibzfs = PyModule_Create(&truenas_pylibzfs);
 	if (mpylibzfs == NULL)
-		return (NULL);
+		return NULL;
 
 	if (types_ready(mpylibzfs) < 0) {
 		Py_DECREF(mpylibzfs);
-		return (NULL);
+		return NULL;
 	}
 
 	constants = PyModule_Create(&truenas_pylibzfs_constants);
-	if (constants == NULL) {
-		Py_DECREF(mpylibzfs);
-		return (NULL);
-	}
+	if (constants != NULL)
+		add_constants(constants);
 
-	add_constants(constants);
-
-	if (PyModule_AddObject(mpylibzfs, "constants", constants) < 0) {
-		Py_DECREF(constants);
+	err = PyModule_AddObjectRef(mpylibzfs, "constants", constants);
+	Py_XDECREF(constants);
+	if (err) {
 		Py_DECREF(mpylibzfs);
-		return (NULL);
+		return NULL;
 	}
 
 	py_init_libzfs();
 
 	lzc = py_setup_lzc_module();
-	if (lzc == NULL) {
+	err = PyModule_AddObjectRef(mpylibzfs, "lzc", lzc);
+	Py_XDECREF(lzc);
+	if (err) {
 		Py_DECREF(mpylibzfs);
-		return (NULL);
-	}
-
-	if (PyModule_AddObject(mpylibzfs, "lzc", lzc) < 0) {
-		Py_DECREF(lzc);
-		Py_DECREF(mpylibzfs);
-		return (NULL);
+		return NULL;
 	}
 
 	zfs_exc = setup_zfs_exception();
-	if (zfs_exc == NULL) {
+	err = PyModule_AddObjectRef(mpylibzfs, "ZFSException", zfs_exc);
+	Py_XDECREF(zfs_exc);
+	if (err) {
 		Py_DECREF(mpylibzfs);
-		return (NULL);
-	}
-
-	if (PyModule_AddObject(mpylibzfs, "ZFSException", zfs_exc) < 0) {
-		Py_DECREF(mpylibzfs);
-		return (NULL);
+		return NULL;
 	}
 
 	if (py_add_zfs_enums(mpylibzfs)) {
 		Py_DECREF(mpylibzfs);
-		return (NULL);
+		return NULL;
 	}
 
 	if (init_py_zfs_state(mpylibzfs) < 0) {
 		Py_DECREF(mpylibzfs);
-		return (NULL);
+		return NULL;
+	}
+
+	propsets = py_setup_propset_module(mpylibzfs);
+	err = PyModule_AddObjectRef(mpylibzfs, "property_sets", propsets);
+	Py_XDECREF(propsets);
+	if (err) {
+		Py_DECREF(mpylibzfs);
+		return NULL;
 	}
 
 	return (mpylibzfs);

--- a/src/truenas_pylibzfs.h
+++ b/src/truenas_pylibzfs.h
@@ -380,6 +380,9 @@ extern PyObject *py_zfs_get_properties(py_zfs_obj_t *pyzfs,
 
 extern PyObject *py_zfs_props_to_dict(py_zfs_obj_t *pyzfs, PyObject *pyprops);
 
+/* Set up propset module with frozensets */
+extern PyObject *py_setup_propset_module(PyObject *parent);
+
 /* Provided by nvlist_utils.c */
 extern PyObject *user_props_nvlist_to_py_dict(nvlist_t *userprops);
 extern nvlist_t *py_userprops_dict_to_nvlist(PyObject *pyprops);


### PR DESCRIPTION
This commit creates a submodule "property_sets" and adds various frozenset sets of properties for end-users to use when retrieving ZFS properties. An example is also added to show how to use property sets when retrieving dataset information recursively.