### PR TITLE
Fix memory leak in libzfs_core

### DIFF
--- a/examples/user_hold_context_manager.py
+++ b/examples/user_hold_context_manager.py
@@ -28,11 +28,11 @@ def temporary_holds(holds):
 
 
 lz = truenas_pylibzfs.open_handle()
-assert not lz.open_resouce(name='dozer/share@now').get_holds()
+assert not lz.open_resource(name='dozer/share@now').get_holds()
 
-with temporary_holds({('dozer/share@now', 'temp_hold'}) as missing:
-    assert lz.open_resouce(name='dozer/share@now').get_holds()
+with temporary_holds({('dozer/share@now', 'temp_hold')}) as missing:
+    assert lz.open_resource(name='dozer/share@now').get_holds()
 
     os.listdir('/mnt/dozer/share/.zfs/snapshot/now')
 
-assert not lz.open_resouce(name='dozer/share@now').get_holds()
+assert not lz.open_resource(name='dozer/share@now').get_holds()

--- a/src/libzfs/py_zfs_snapshot.c
+++ b/src/libzfs/py_zfs_snapshot.c
@@ -82,6 +82,7 @@ PyObject *py_zfs_snapshot_get_holds(PyObject *self, PyObject *args_unused)
 	py_zfs_snapshot_t *ds = (py_zfs_snapshot_t *)self;
 	nvlist_t *holds = NULL;
 	py_zfs_error_t zfs_err;
+	PyObject *out = NULL;
 	int err;
 
 	Py_BEGIN_ALLOW_THREADS
@@ -100,7 +101,9 @@ PyObject *py_zfs_snapshot_get_holds(PyObject *self, PyObject *args_unused)
 	if (holds == NULL)
 		return PyTuple_New(0);
 
-	return py_nvlist_names_tuple(holds);
+	out = py_nvlist_names_tuple(holds);
+	fnvlist_free(holds);
+	return out;
 }
 
 static

--- a/src/libzfs_core/py_zfs_core_module.c
+++ b/src/libzfs_core/py_zfs_core_module.c
@@ -103,7 +103,7 @@ void setup_zfs_core_exception(PyObject *module)
 	PYZFS_ASSERT(dict, "Failed to set up ZFSCoreException");
 
 	state->zc_exc = PyErr_NewExceptionWithDoc(PYLIBZFS_MODULE_NAME
-						  "lzc.ZFSCoreException",
+						  ".lzc.ZFSCoreException",
 						  py_zfs_core_exception__doc__,
 						  PyExc_RuntimeError,
 						  dict);
@@ -641,7 +641,7 @@ static PyObject *py_lzc_create_holds(PyObject *self,
 	char *kwnames [] = { "holds", "cleanup_fd", NULL };
 
 	if (!PyArg_ParseTupleAndKeywords(args_unused, kwargs,
-					 "|$O",
+					 "|$Oi",
 					 kwnames,
 					 &py_holds,
 					 &cleanup_fd)) {
@@ -1079,7 +1079,7 @@ PYLIBZFS_MODULE_NAME " provides python bindings for libzfs_core for TrueNAS.\n"
 /* Module structure */
 static struct PyModuleDef truenas_pylibzfs_core = {
 	.m_base = PyModuleDef_HEAD_INIT,
-	.m_name = PYLIBZFS_MODULE_NAME,
+	.m_name = PYLIBZFS_MODULE_NAME ".lzc",
 	.m_doc = py_zfs_core_module__doc__,
 	.m_size = sizeof(pylibzfs_core_state_t),
 	.m_methods = TruenasPylibzfsCoreMethods,


### PR DESCRIPTION
This commit fixes a memory leak when retrieving ZFS holds for a snapshot (we weren't freeing the nvlist returned by libzfs_core). This also fixes some syntax errors in the example script for managing user holds.