### PR TITLE
Normalize properties for zpool history messages

### DIFF
--- a/src/libzfs/py_zfs.c
+++ b/src/libzfs/py_zfs.c
@@ -150,6 +150,27 @@ boolean_t py_zfs_create(py_zfs_t *self,
 	PY_ZFS_UNLOCK(self);
 	Py_END_ALLOW_THREADS
 
+	if (props) {
+		const char *json_str = NULL;
+		PyObject *dump = py_dump_nvlist(props, B_TRUE);
+		if (dump != NULL) {
+			json_str = PyUnicode_AsUTF8(dump);
+		}
+		err = py_log_history_fmt(self, "zfs create %s with properties: %s",
+					 name, json_str ? json_str: "UNKNOWN");
+		Py_XDECREF(dump);
+		if (err) {
+			fnvlist_free(props);
+			return B_FALSE;
+		}
+	} else {
+		err = py_log_history_fmt(self, "zfs create %s", name);
+		if (err) {
+			fnvlist_free(props);
+			return B_FALSE;
+		}
+	}
+
 	fnvlist_free(props);
 
 	if (err) {

--- a/src/truenas_pylibzfs.h
+++ b/src/truenas_pylibzfs.h
@@ -393,4 +393,5 @@ extern nvlist_t *py_zfsprops_to_nvlist(pylibzfs_state_t *state,
 				       PyObject *pydict,
 				       zfs_type_t type,
 				       boolean_t allow_ro);
+extern PyObject *py_dump_nvlist(nvlist_t *nvl, boolean_t json);
 #endif  /* _TRUENAS_PYLIBZFS_H */


### PR DESCRIPTION
This commit normalizes zfs properties via JSON dump of the properties nvlist prior to writing a zpool history message.

In the process of adding this a general-purpose function has been introduced to convert an nvlist into a python unicode object via libzfs nvlist dump functions (either generic pretty-printed or as JSON).