### PR TITLE
Add iterator for root datasets

### DIFF
--- a/examples/iter_root_datasets.py
+++ b/examples/iter_root_datasets.py
@@ -1,0 +1,38 @@
+# This code snippet demonstrats how to iterate the
+# root level datasets of all imported pools.
+import truenas_pylibzfs
+
+def print_dataset_names(hdl, state):
+    print(hdl.name)
+    state["datasets"].append(hdl)
+    if state["recursive"]:
+        hdl.iter_filesystems(
+            callback=print_dataset_names,
+            state=state
+        )
+
+    return True
+
+
+lz = truenas_pylibzfs.open_handle()
+
+# First non-recursive
+state = {
+    "recursive": False,
+    "datasets": []
+}
+
+lz.iter_root_datasets(callback=print_dataset_names, state=state)
+first_len = len(state["datasets"])
+assert first_len != 0
+
+first_len = len(state["datasets"])
+
+# Now recursively
+state = {
+    "recursive": True,
+    "datasets": []
+}
+
+lz.iter_root_datasets(callback=print_dataset_names, state=state)
+assert len(state["datasets"]) != first_len

--- a/src/libzfs/py_zfs_iter.c
+++ b/src/libzfs/py_zfs_iter.c
@@ -376,7 +376,7 @@ py_iter_root_datasets(py_iter_state_t *state)
 	ITER_END_ALLOW_THREADS(state);
 
 	if (iter_ret == ITER_RESULT_IOCTL_ERROR) {
-		set_exc_from_libzfs(&zfs_err, "zfs_iter_filesystems_v2() failed");
+		set_exc_from_libzfs(&zfs_err, "zfs_iter_root() failed");
 	}
 
 	return iter_ret;

--- a/src/libzfs/py_zfs_iter.h
+++ b/src/libzfs/py_zfs_iter.h
@@ -72,5 +72,6 @@ typedef struct {
 extern int py_iter_filesystems(py_iter_state_t *state);
 extern int py_iter_snapshots(py_iter_state_t *state);
 extern int py_iter_userspace(py_iter_state_t *state);
+extern int py_iter_root_datasets(py_iter_state_t *state);
 
 #endif  /* _PY_ZFS_ITER_H */

--- a/src/truenas_pylibzfs_state.c
+++ b/src/truenas_pylibzfs_state.c
@@ -247,6 +247,7 @@ void free_py_zfs_state(PyObject *module)
 	Py_CLEAR(state->struct_zfs_props_type);
 	Py_CLEAR(state->struct_zfs_prop_type);
 	Py_CLEAR(state->struct_zfs_prop_src_type);
+	Py_CLEAR(state->struct_zfs_userquota_type);
 
 	Py_CLEAR(state->zfs_property_src_enum);
 	Py_CLEAR(state->zfs_property_enum);

--- a/src/truenas_pylibzfs_state.h
+++ b/src/truenas_pylibzfs_state.h
@@ -49,6 +49,9 @@ typedef struct {
 	 */
 	PyTypeObject *struct_zfs_prop_src_type;
 
+	/* Reference to named tuple for ZFS user quota */
+	PyTypeObject *struct_zfs_userquota_type;
+
 	/*
 	 * References to enums that are available in the base
 	 * of module. We have them in state so that we can


### PR DESCRIPTION
This commit adds a root dataset iterator for the base of the module. This is useful for recursive operations on all imported pools.