### PR TITLE
Make assertion on module load more informative

### DIFF
--- a/src/truenas_pylibzfs.c
+++ b/src/truenas_pylibzfs.c
@@ -156,7 +156,12 @@ void py_init_libzfs(void)
 	// we can build our Struct Sequences with correct values
 
 	tmplz = libzfs_init();
-	PYZFS_ASSERT(tmplz, "Failed to initialize libzfs");
+	if (!tmplz) {
+		char err[256];
+		snprintf(err, sizeof(err), "Failed to initialize libzfs: %s", strerror(errno));
+		PYZFS_ASSERT(tmplz, err);
+	}
+
 	libzfs_fini(tmplz);
 }
 


### PR DESCRIPTION
Initialization of libzfs data structures at module load is an absolute requirement for truenas_pylibzfs to function in a well defined manner. This commit makes the error message a little more useful without reviewing the corefile.