### PR TITLE
Improve query example and add recursive functionality

### DIFF
--- a/examples/filterable_query.py
+++ b/examples/filterable_query.py
@@ -39,12 +39,14 @@ def generic_query_callback(hdl, state):
     else:
         state.results.append(data)
 
-    if state.single_result or not state.recursive:
+    if state.single_result:
         # halt iterator
         return False
 
-    # recursive
-    getattr(hdl, state.iterator_fn_name)(callback=generic_query_callback, state=state)
+    if state.recursive:
+        getattr(hdl, state.iterator_fn_name)(
+            callback=generic_query_callback, state=state
+        )
 
     return True
 
@@ -94,24 +96,23 @@ def generic_query(
 
         return state.results[0]
 
-    if options["offset"]:
-        results = results[options["offset"] :]
+    if offset := options.get("offset", 0):
+        results = results[offset:]
 
-    if options["limit"]:
-        results = results[: options["limit"]]
+    if limit := options.get("limit", 0):
+        results = results[:limit]
 
     return results
 
 
 lz = open_handle()
 rsrc = lz.open_resource(name="dozer")
-
 print("RECURSIVE FILESYSTEM:")
 pprint(
     generic_query(
         rsrc.iter_filesystems,
         [],
-        {"offset": 0, "limit": 0, "get": False, "count": False, "select": []},
+        {"get": False, "count": False, "select": []},
         {"recursive": True},
     )
 )

--- a/examples/filterable_query.py
+++ b/examples/filterable_query.py
@@ -1,15 +1,16 @@
-import truenas_pylibzfs
 from dataclasses import dataclass
+from pprint import pprint
 
 from middlewared.utils import filters, get_impl
 from middlewared.service_exception import MatchNotFound
+from truenas_pylibzfs import open_handle, ZFSProperty
 
 generic_filters = filters()
 
 
-@dataclass
+@dataclass(slots=True, kw_only=True)
 class QueryFiltersCallbackState:
-    # query-filters, query-options fields
+    iterator_fn_name: str  # the name of function doing the iteration(s)
     filters: list  # query-filters
     filter_fn: callable  # function to do filtering
     get_fn: callable  # function to get value from dict
@@ -17,11 +18,8 @@ class QueryFiltersCallbackState:
     select: list | None = None  # list of fields to select. None means all.
     single_result: bool = False  # return single result with no pagination
     count_only: bool = False  # only count entries
-
-    # ZFS fields
-    propset: set | None = None  # set of properties to retrieve
-
-    # results will be one of following
+    recursive: bool = False  # recursively iterate
+    propset: set[ZFSProperty] | None = None  # zfs properties to retrieve
     results: list = None
     count: int = 0
 
@@ -41,36 +39,42 @@ def generic_query_callback(hdl, state):
     else:
         state.results.append(data)
 
-    if state.single_result:
+    if state.single_result or not state.recursive:
         # halt iterator
         return False
+
+    # recursive
+    getattr(hdl, state.iterator_fn_name)(callback=generic_query_callback, state=state)
 
     return True
 
 
-def generic_query(rsrc_iterator, filters_in, options_in, zfs_options):
+def generic_query(
+    rsrc_iterator: callable,
+    filters_in: list,
+    options_in: dict,
+    zfs_options: dict,
+):
     # parse query-options
     options, select, order_by = generic_filters.validate_options(options_in)
 
     # set up callback state
     state = QueryFiltersCallbackState(
+        iterator_fn_name=rsrc_iterator.__name__,
         filters=filters_in,
         filter_fn=generic_filters.eval_filter,
         get_fn=get_impl,
         select_fn=generic_filters.do_select,
         select=select,
-        single_result=options['get'] and not order_by,
-        count_only=options['count'],
-        propset=zfs_options.pop('propset', None),
-        results=[]
+        single_result=options["get"] and not order_by,
+        count_only=options["count"],
+        recursive=zfs_options.pop("recursive", False),
+        propset=zfs_options.pop("propset", None),
+        results=[],
     )
 
     # do iteration
-    rsrc_iterator(
-        callback=generic_query_callback,
-        state=state,
-        **zfs_options
-    )
+    rsrc_iterator(callback=generic_query_callback, state=state, **zfs_options)
 
     # optimization where request is only for single result with no pagination
     if state.single_result:
@@ -79,29 +83,55 @@ def generic_query(rsrc_iterator, filters_in, options_in, zfs_options):
 
         return state.results[0]
 
-    if options['count']:
+    if options["count"]:
         return state.count
 
     results = generic_filters.do_order(state.results, order_by)
 
-    if options['get']:
+    if options["get"]:
         if not state.results:
             raise MatchNotFound()
 
         return state.results[0]
 
-    if options['offset']:
-        results = results[options['offset']:]
+    if options["offset"]:
+        results = results[options["offset"] :]
 
-    if options['limit']:
-        results = results[:options['limit']]
+    if options["limit"]:
+        results = results[: options["limit"]]
 
     return results
 
 
-lz = truenas_pylibzfs.open_handle()
-rsrc = lz.open_resource(name='dozer')
-options = {'get': True, 'count': False, 'select': []}
+lz = open_handle()
+rsrc = lz.open_resource(name="dozer")
 
-print(generic_query(rsrc.iter_filesystems, [['name', '=', 'dozer/share']], options, {}))
-print(generic_query(rsrc.iter_snapshots, [['name', '=', 'dozer@foo']], options, {'fast': True}))
+print("RECURSIVE FILESYSTEM:")
+pprint(
+    generic_query(
+        rsrc.iter_filesystems,
+        [],
+        {"offset": 0, "limit": 0, "get": False, "count": False, "select": []},
+        {"recursive": True},
+    )
+)
+
+print("\n\nNON-RECURSIVE FILESYSTEM:")
+pprint(
+    generic_query(
+        rsrc.iter_filesystems,
+        [["name", "=", "dozer/share"]],
+        {"get": True, "count": False, "select": []},
+        {},
+    )
+)
+
+print("\n\nNON-RECURSIVE SNAPSHOT:")
+pprint(
+    generic_query(
+        rsrc.iter_snapshots,
+        [["name", "=", "dozer@foo"]],
+        {"get": True, "count": False, "select": []},
+        {"fast": True},
+    )
+)


### PR DESCRIPTION
This simply improves the filterable query example and adds a recursive example. I also use `pprint.pprint` to format the output as I find it easier to read.