### PR TITLE
iter_root_datasets -> iter_root_filesystems

### DIFF
--- a/examples/iter_root_filesystems.py
+++ b/examples/iter_root_filesystems.py
@@ -22,7 +22,7 @@ state = {
     "datasets": []
 }
 
-lz.iter_root_datasets(callback=print_dataset_names, state=state)
+lz.iter_root_filesystems(callback=print_dataset_names, state=state)
 first_len = len(state["datasets"])
 assert first_len != 0
 
@@ -34,5 +34,5 @@ state = {
     "datasets": []
 }
 
-lz.iter_root_datasets(callback=print_dataset_names, state=state)
+lz.iter_root_filesystems(callback=print_dataset_names, state=state)
 assert len(state["datasets"]) != first_len

--- a/src/libzfs/py_zfs.c
+++ b/src/libzfs/py_zfs.c
@@ -423,10 +423,10 @@ PyObject *py_zfs_pool_open(PyObject *self,
 	return (out);
 }
 
-PyDoc_STRVAR(py_zfs_iter_root_datasets__doc__,
-"iter_root_datasets(*, callback, state) -> bool\n\n"
+PyDoc_STRVAR(py_zfs_iter_root_filesystems__doc__,
+"iter_root_filesystems(*, callback, state) -> bool\n\n"
 "----------------------------------------------\n\n"
-"Iterate root datasets for all imported zpools\n\n"
+"Iterate root filesystems for all imported zpools\n\n"
 "Parameters\n"
 "----------\n"
 "callback: callable\n"
@@ -457,7 +457,7 @@ PyDoc_STRVAR(py_zfs_iter_root_datasets__doc__,
 "    return True\n"
 );
 static
-PyObject *py_zfs_iter_root_datasets(PyObject *self,
+PyObject *py_zfs_iter_root_filesystems(PyObject *self,
 					   PyObject *args_unused,
 					   PyObject *kwargs)
 {
@@ -492,12 +492,12 @@ PyObject *py_zfs_iter_root_datasets(PyObject *self,
 	}
 
 	// There aren't any useful arguments we can pass to sys.audit
-	if (PySys_Audit(PYLIBZFS_MODULE_NAME ".iter_root_datasets",
+	if (PySys_Audit(PYLIBZFS_MODULE_NAME ".iter_root_filesystems",
 			"O", Py_None) < 0) {
 		return NULL;
 	}
 
-	err = py_iter_root_datasets(&iter_state);
+	err = py_iter_root_filesystems(&iter_state);
 	if ((err == ITER_RESULT_ERROR) || (err == ITER_RESULT_IOCTL_ERROR)) {
 		// Exception is set by callback function
 		return NULL;
@@ -531,10 +531,10 @@ PyMethodDef zfs_methods[] = {
 		.ml_flags = METH_VARARGS | METH_KEYWORDS
 	},
 	{
-		.ml_name = "iter_root_datasets",
-		.ml_meth = (PyCFunction)py_zfs_iter_root_datasets,
+		.ml_name = "iter_root_filesystems",
+		.ml_meth = (PyCFunction)py_zfs_iter_root_filesystems,
 		.ml_flags = METH_VARARGS | METH_KEYWORDS,
-		.ml_doc = py_zfs_iter_root_datasets__doc__
+		.ml_doc = py_zfs_iter_root_filesystems__doc__
 	},
 	{
 		.ml_name = "open_pool",

--- a/src/libzfs/py_zfs_iter.c
+++ b/src/libzfs/py_zfs_iter.c
@@ -355,7 +355,7 @@ py_iter_userspace(py_iter_state_t *state)
 }
 
 int
-py_iter_root_datasets(py_iter_state_t *state)
+py_iter_root_filesystems(py_iter_state_t *state)
 {
 	int iter_ret;
 	py_zfs_error_t zfs_err;

--- a/src/libzfs/py_zfs_iter.h
+++ b/src/libzfs/py_zfs_iter.h
@@ -72,6 +72,6 @@ typedef struct {
 extern int py_iter_filesystems(py_iter_state_t *state);
 extern int py_iter_snapshots(py_iter_state_t *state);
 extern int py_iter_userspace(py_iter_state_t *state);
-extern int py_iter_root_datasets(py_iter_state_t *state);
+extern int py_iter_root_filesystems(py_iter_state_t *state);
 
 #endif  /* _PY_ZFS_ITER_H */


### PR DESCRIPTION
This renames the user-facing `iter_root_datasets` method to `iter_root_filesystems`. This follows convention with other user-facing methods.