### PR TITLE
change pool_name kwarg to name

### DIFF
--- a/src/libzfs/py_zfs.c
+++ b/src/libzfs/py_zfs.c
@@ -380,7 +380,7 @@ PyObject *py_zfs_pool_open(PyObject *self,
 	char *name = NULL;
 	py_zfs_error_t zfs_err;
 
-	char *kwnames [] = { "pool_name", NULL };
+	char *kwnames [] = { "name", NULL };
 
 	if (!PyArg_ParseTupleAndKeywords(args_unused, kwargs,
 					"$s",
@@ -393,7 +393,7 @@ PyObject *py_zfs_pool_open(PyObject *self,
 		PyErr_SetString(PyExc_ValueError,
 				"The name of the pool to open must be "
 				"passed to this method through the "
-				"\"pool_name\" keyword argument.");
+				"\"name\" keyword argument.");
 		return NULL;
 	}
 


### PR DESCRIPTION
The user-facing method is called `pool_open`. There is no need to enforce the keyword argument to be named "pool_name" as it's redundant. Furthermore, the convention followed in other user-facing methods is to use the `name` kwarg. This converts it from `pool_name` to `name` to match convention.