### PR TITLE
Fix crash in ZFS userspace

### DIFF
--- a/src/libzfs/py_zfs_iter.c
+++ b/src/libzfs/py_zfs_iter.c
@@ -218,7 +218,11 @@ out:
 }
 
 static int
-userspace_callback(void *private, const char *dom, uid_t xid, uint64_t val)
+userspace_callback(void *private,
+		   const char *dom,
+		   uid_t xid,
+		   uint64_t val,
+		   uint64_t default_quota)
 {
 	int result = ITER_RESULT_ERROR;
 	py_iter_state_t *state = (py_iter_state_t *)private;
@@ -229,7 +233,7 @@ userspace_callback(void *private, const char *dom, uid_t xid, uint64_t val)
 
 	// intentionally omit domain from python layer
 	pyquota = py_zfs_userquota(conf.pyuserquota_struct,
-				   conf.pyqtype, xid, val);
+				   conf.pyqtype, xid, val, default_quota);
 	if (pyquota == NULL)
 		goto out;
 
@@ -337,7 +341,7 @@ py_iter_userspace(py_iter_state_t *state)
 
 	iter_ret = zfs_userspace(state->target,
 				 conf.qtype,
-				 (zfs_userspace_cb_t)userspace_callback,
+				 userspace_callback,
 				 (void *)state);
 
 	if (iter_ret == ITER_RESULT_IOCTL_ERROR) {

--- a/src/libzfs/py_zfs_userquota.c
+++ b/src/libzfs/py_zfs_userquota.c
@@ -8,7 +8,7 @@ PyStructSequence_Field struct_zfs_userquota [] = {
 	{"quota_type", "ZFSUserQuota enum identifying quota type."},
 	{"xid", "Either unix ID or RID (solaris SMB) to which quota applies."},
 	{"value", "The numeric value of the quota."},
-	{"default", "The numeric value of any default quota."},
+	{"default", "The numeric value of the default value for this quota type."},
 	{0},
 };
 
@@ -33,7 +33,7 @@ PyObject *py_zfs_userquota(PyTypeObject *userquota_struct,
 			   PyObject *pyqtype,
 			   uid_t xid,
 			   uint64_t value,
-			   uint64_t default_value)
+			   uint64_t default_quota)
 {
 	PyObject *pyxid;
 	PyObject *pyval;
@@ -51,7 +51,7 @@ PyObject *py_zfs_userquota(PyTypeObject *userquota_struct,
 		return NULL;
 	}
 
-	pydef = PyLong_FromUnsignedLong(default_value);
+	pydef = PyLong_FromUnsignedLong(default_quota);
 	if (pydef == NULL) {
 		Py_DECREF(pyxid);
 		Py_DECREF(pyval);

--- a/src/truenas_pylibzfs.h
+++ b/src/truenas_pylibzfs.h
@@ -401,7 +401,8 @@ extern void init_py_struct_userquota_state(pylibzfs_state_t *state);
 extern PyObject *py_zfs_userquota(PyTypeObject *qtypestruct,
 				  PyObject *pyqtype,
 				  uid_t xid,
-				  uint64_t value);
+				  uint64_t value,
+				  uint64_t default_quota);
 extern nvlist_t *py_userquotas_to_nvlist(pylibzfs_state_t *state, PyObject *uquotas);
 
 /* py_zfs_mount.c */


### PR DESCRIPTION
This commit fixes two issues with ZFS userspace:

* Reference counting bug in truenas-pylibzfs when creating
  struct userspace quota
* Invalid function definition for zfs_userspace_cb_t. Introduced
  by not accounting for upstream changes in the aforementioned
  callback type.