### PR TITLE
Optimize reading resource crypto information

### DIFF
--- a/src/libzfs/py_zfs_crypto.c
+++ b/src/libzfs/py_zfs_crypto.c
@@ -244,17 +244,9 @@ PyObject *py_zfs_crypto_info_dict(py_zfs_obj_t *obj)
 {
 	PyObject *out = NULL;
 	PyObject *info_struct = NULL;
-	uint64_t encrypt;
 	int idx;
 
-	/* Do not require caller to pre-check encryption status */
-	Py_BEGIN_ALLOW_THREADS
-	PY_ZFS_LOCK(obj->pylibzfsp);
-	encrypt = zfs_prop_get_int(obj->zhp, ZFS_PROP_ENCRYPTION);
-	PY_ZFS_UNLOCK(obj->pylibzfsp);
-	Py_END_ALLOW_THREADS
-
-	if (encrypt == ZIO_CRYPT_OFF)
+	if (obj->encrypted == Py_False)
 		Py_RETURN_NONE;
 
 	info_struct = py_zfs_crypto_info_struct(obj);

--- a/src/libzfs/py_zfs_dataset.c
+++ b/src/libzfs/py_zfs_dataset.c
@@ -265,6 +265,9 @@ PyObject *py_zfs_dataset_crypto(PyObject *self, PyObject *args_unused)
 	py_zfs_obj_t *obj = RSRC_TO_ZFS(((py_zfs_dataset_t *)self));
 	uint64_t keyformat = ZFS_KEYFORMAT_NONE;
 
+	if (obj->encrypted == Py_False)
+		Py_RETURN_NONE;
+
         // PY_ZFS_LOCK needs held due to interaction with libzfs mnttab
 	Py_BEGIN_ALLOW_THREADS
 	PY_ZFS_LOCK(obj->pylibzfsp);
@@ -328,6 +331,7 @@ py_zfs_dataset_t *init_zfs_dataset(py_zfs_t *lzp, zfs_handle_t *zfsp, boolean_t 
 	const char *pool_name;
 	zfs_type_t zfs_type;
 	uint64_t guid, createtxg;
+	boolean_t is_encrypted = B_FALSE;
 
 	out = (py_zfs_dataset_t *)PyObject_CallFunction((PyObject *)&ZFSDataset, NULL);
 	if (out == NULL) {
@@ -344,6 +348,7 @@ py_zfs_dataset_t *init_zfs_dataset(py_zfs_t *lzp, zfs_handle_t *zfsp, boolean_t 
 	pool_name = zfs_get_pool_name(zfsp);
 	guid = zfs_prop_get_int(zfsp, ZFS_PROP_GUID);
 	createtxg = zfs_prop_get_int(zfsp, ZFS_PROP_CREATETXG);
+	is_encrypted = zfs_is_encrypted(zfsp);
 	Py_END_ALLOW_THREADS
 
 	obj->name = PyUnicode_FromString(ds_name);
@@ -364,6 +369,7 @@ py_zfs_dataset_t *init_zfs_dataset(py_zfs_t *lzp, zfs_handle_t *zfsp, boolean_t 
 	if (obj->createtxg == NULL)
 		goto error;
 
+	obj->encrypted = Py_NewRef(is_encrypted ? Py_True : Py_False);
 	obj->zhp = zfsp;
 	return out;
 

--- a/src/libzfs/py_zfs_object.c
+++ b/src/libzfs/py_zfs_object.c
@@ -35,6 +35,7 @@ void free_py_zfs_obj(py_zfs_obj_t *self)
 	Py_CLEAR(self->pylibzfsp);
 	Py_CLEAR(self->guid);
 	Py_CLEAR(self->createtxg);
+	Py_CLEAR(self->encrypted);
 }
 
 static
@@ -267,6 +268,15 @@ PyObject *py_zfs_obj_get_pool(py_zfs_obj_t *self, void *extra) {
 	return py_get_prop(self->pool_name);
 }
 
+PyDoc_STRVAR(py_zfs_obj_encrypted__doc__,
+"If set, the ZFS resource is encrypted. This does not show if the resource is "
+"locked or unlocked. To get more infomration, call the crypto() method.\n"
+);
+static
+PyObject *py_zfs_obj_get_encrypted(py_zfs_obj_t *self, void *extra) {
+	return py_get_prop(self->encrypted);
+}
+
 static
 PyGetSetDef zfs_obj_getsetters[] = {
 	{
@@ -293,6 +303,11 @@ PyGetSetDef zfs_obj_getsetters[] = {
 		.name	= "pool_name",
 		.get	= (getter)py_zfs_obj_get_pool,
 		.doc	= py_zfs_obj_pool_name__doc__,
+	},
+	{
+		.name	= "encrypted",
+		.get	= (getter)py_zfs_obj_get_encrypted,
+		.doc	= py_zfs_obj_encrypted__doc__,
 	},
 	{ .name = NULL }
 };

--- a/src/libzfs/py_zfs_snapshot.c
+++ b/src/libzfs/py_zfs_snapshot.c
@@ -150,6 +150,7 @@ py_zfs_snapshot_t *init_zfs_snapshot(py_zfs_t *lzp, zfs_handle_t *zfsp, boolean_
 	const char *pool_name;
 	zfs_type_t zfs_type;
 	uint64_t guid, createtxg;
+	boolean_t is_encrypted = B_FALSE;
 
 	out = (py_zfs_snapshot_t *)PyObject_CallFunction((PyObject *)&ZFSSnapshot, NULL);
 	if (out == NULL) {
@@ -166,6 +167,7 @@ py_zfs_snapshot_t *init_zfs_snapshot(py_zfs_t *lzp, zfs_handle_t *zfsp, boolean_
 	pool_name = zfs_get_pool_name(zfsp);
 	guid = zfs_prop_get_int(zfsp, ZFS_PROP_GUID);
 	createtxg = zfs_prop_get_int(zfsp, ZFS_PROP_CREATETXG);
+	is_encrypted = zfs_is_encrypted(zfsp);
 	Py_END_ALLOW_THREADS
 
 	PYZFS_ASSERT((zfs_type == ZFS_TYPE_SNAPSHOT), "Incorrect ZFS type");
@@ -188,6 +190,7 @@ py_zfs_snapshot_t *init_zfs_snapshot(py_zfs_t *lzp, zfs_handle_t *zfsp, boolean_
 	if (obj->createtxg == NULL)
 		goto error;
 
+	obj->encrypted = Py_NewRef(is_encrypted ? Py_True : Py_False);
 	obj->zhp = zfsp;
 	return out;
 

--- a/src/truenas_pylibzfs.h
+++ b/src/truenas_pylibzfs.h
@@ -83,6 +83,7 @@ typedef struct {
 	PyObject *guid;
 	PyObject *createtxg;
 	PyObject *pool_name;
+	PyObject *encrypted;
 } py_zfs_obj_t;
 
 /*


### PR DESCRIPTION
This commit optimizes lookups for ZFS dataset crypto information by adding a boolean value to the root of dataset to indicate whether it's encrypted and short-circuit retrieval of crypto object.

A new attribute for ZFS objects `encrypted` is also added.

```
>>> rsrc = hdl.open_resource(name='dozer/ENC')
>>> rsrc.encrypted
True
```