### PR TITLE
NAS-136891 / 25.10 / Add method to change crypto key

### DIFF
--- a/src/libzfs/py_zfs_crypto.c
+++ b/src/libzfs/py_zfs_crypto.c
@@ -86,7 +86,7 @@ PyDoc_STRVAR(py_zfs_crypto_pbkdf2_iters__doc__,
 "Valid pbkdf2_iters values include:\n"
 "* An integer greater than or equal to the minimum allowed value.\n"
 "* The value None. If set to None, the library uses the minimum allowed value.\n"
-"NOTE: this setting is valid only if the \"passphrase\" \"keyformat\" is selected.\n"
+"NOTE: This setting is valid only if the \"passphrase\" \"keyformat\" is selected.\n"
 );
 
 PyDoc_STRVAR(py_zfs_crypto_change__doc__,

--- a/src/libzfs/py_zfs_crypto.c
+++ b/src/libzfs/py_zfs_crypto.c
@@ -28,7 +28,7 @@ PyDoc_STRVAR(py_zfs_crypto_keylocation__doc__,
 "Valid keylocation values include:\n"
 "* Absolute paths in the local file system, starting with file://\n"
 "* HTTPS URLs (fetched using fetch(3) from libcurl)\n"
-"* The word prompt, which tells the server to ask the user for the key\n\n"
+"* The word 'prompt', which tells the server to ask the user for the key\n\n"
 "NOTE: This field is valid only if the resource is an encryption root.\n"
 );
 

--- a/src/truenas_pylibzfs_state.c
+++ b/src/truenas_pylibzfs_state.c
@@ -249,7 +249,8 @@ void free_py_zfs_state(PyObject *module)
 	Py_CLEAR(state->struct_zfs_prop_type);
 	Py_CLEAR(state->struct_zfs_prop_src_type);
 	Py_CLEAR(state->struct_zfs_userquota_type);
-	Py_CLEAR(state->struct_zfs_crytpo_info_type);
+	Py_CLEAR(state->struct_zfs_crypto_info_type);
+	Py_CLEAR(state->struct_zfs_crypto_change_type);
 
 	Py_CLEAR(state->zfs_property_src_enum);
 	Py_CLEAR(state->zfs_property_enum);

--- a/src/truenas_pylibzfs_state.h
+++ b/src/truenas_pylibzfs_state.h
@@ -53,7 +53,10 @@ typedef struct {
 	PyTypeObject *struct_zfs_userquota_type;
 
 	/* Reference to named tuple for crypto info */
-	PyTypeObject *struct_zfs_crytpo_info_type;
+	PyTypeObject *struct_zfs_crypto_info_type;
+
+	/* Reference to named tuple for crypto config (for creation / update) */
+	PyTypeObject *struct_zfs_crypto_change_type;
 
 	/*
 	 * References to enums that are available in the base


### PR DESCRIPTION
This commit adds a change_key method to the ZFS cryptography object, which may be used to rewrap the crypto key on an existing encrypted ZFS resource (dataset or volume). It also creates a new struct sequence object for cryptography information that will be consumed when creating new encrypted resources.