### PR TITLE
Improve the API for testing crypto keys

### DIFF
--- a/examples/encryption.py
+++ b/examples/encryption.py
@@ -47,11 +47,21 @@ assert crypto_dict['encryption_root'] == rsrc.name
 assert crypto_dict['key_location'] == 'prompt'
 assert crypto_dict['key_is_loaded'] is False
 
+# Test load shouldn't actually load the key
+assert enc.check_key(key=PASSKEY) is True
+crypto_dict = rsrc.asdict(get_crypto=True)['crypto']
+assert crypto_dict['is_root'] is True
+assert crypto_dict['encryption_root'] == rsrc.name
+assert crypto_dict['key_location'] == 'prompt'
+assert crypto_dict['key_is_loaded'] is False
+
 # load key / unload key / load key / mount
 # to verify that properties are being refreshed
 enc.load_key(key=PASSKEY)
 enc.unload_key()
 enc.load_key(key=PASSKEY)
 rsrc.mount()
+
+assert enc.check_key(key="CANARY1234") is False
 
 assert rsrc.get_mountpoint()


### PR DESCRIPTION
This commit adds a new crypto object method `check_key` that returns a boolean value indicating whether the provided crypto material can be used to unlock the resource.