### PR TITLE
NAS-137470 / 25.10-RC.1 / Fix crypto setup with hex passphrase (by anodos325)

### DIFF
--- a/examples/create_encrypted_dataset.py
+++ b/examples/create_encrypted_dataset.py
@@ -27,3 +27,8 @@ enc.unload_key()
 enc.load_key(key=PASSKEY2)
 
 z.destroy_resource(name='dozer/enc')
+
+# Create a hex key-format dataset
+c = z.resource_cryptography_config(keyformat="hex", key="1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+z.create_resource(name='dozer/enc', type=truenas_pylibzfs.ZFSType.ZFS_TYPE_FILESYSTEM, crypto=c)
+z.destroy_resource(name='dozer/enc')

--- a/src/libzfs/py_zfs_crypto.c
+++ b/src/libzfs/py_zfs_crypto.c
@@ -202,6 +202,10 @@ boolean_t validate_keyformat(PyObject *py_keyformat,
 	if ((format != ZFS_KEYFORMAT_PASSPHRASE) || NULL_OR_NONE(py_iters)) {
 		info->format = format;
 		info->format_str = keyformat_str;
+		if (format != ZFS_KEYFORMAT_PASSPHRASE) {
+			// ensure that iterations are omitted if not passphrase
+			info->iters = 0;
+		}
 		return B_TRUE;
 	}
 


### PR DESCRIPTION
This commit ensures that pbkdf2_iterations is set to zero in case crypo material isn't a passphrase. We were intializing it to the library-defined minimum in case it was unspecified in crypto payload.

Original PR: https://github.com/truenas/truenas_pylibzfs/pull/108
